### PR TITLE
Update readme with pycryptodome instructions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
-include snet_cli/resources/Agent.json
-include snet_cli/resources/AgentFactory.json
-include snet_cli/resources/Job.json
-include snet_cli/resources/Registry.json
-include snet_cli/resources/SingularityNetToken.json
+include snet_cli/resources/contracts/Agent.json
+include snet_cli/resources/contracts/AgentFactory.json
+include snet_cli/resources/contracts/Job.json
+include snet_cli/resources/contracts/Registry.json
+include snet_cli/resources/contracts/SingularityNetToken.json

--- a/README.md
+++ b/README.md
@@ -17,6 +17,28 @@ These instructions are intended to facilitate the development and use of the Sin
 ```bash
 $ pip install snet-cli
 ```
+
+#### If you get "ImportError: cannot import name 'scrypt'" when first running snet-cli
+
+Until ledgerblue replaces their dependency on pycrypto (deprecated) with pycryotodome (a drop-in
+replacement), the presence of both on the system may cause errors when importing various crypto
+dependencies. Removing both libraries and installing them in the following order should resolve
+this issue should it happen to you.
+
+* Uninstall pycrypto and pycryptodome
+```bash
+$ pip uninstall pycrypto pycryptodome
+```
+
+* Reinstall pycrypto
+```bash
+$ pip install pycrypto
+```
+
+* Reinstall pycryptodome
+```bash
+$ pip install pycryptodome
+```
   
 ### Installing (For Development)
   

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='snet-cli',
-    version='0.1.0',
+    version='0.1.1',
     packages=['snet_cli'],
     scripts=['bin/snet'],
     url='https://github.com/singnet/snet-cli',


### PR DESCRIPTION
Some users will experience "ImportError: cannot import name 'scrypt'" depending on the ordering of the installation of pycrypto and pycryptodome within their Python environments. Unfortunately, our dependency tree includes both. Added directions on how to resolve the issue as well as opened https://github.com/LedgerHQ/blue-loader-python/issues/44 to hopefully fix this in the future. 

Fixed an issue with the MANIFEST.in file. This bug forced an update to 0.1.1 as PyPi disallows reuse of the same version.