### PR TITLE
Keep secrets out of command line history and terminal scrollback

### DIFF
--- a/snet_cli/identity.py
+++ b/snet_cli/identity.py
@@ -283,12 +283,15 @@ class LedgerIdentityProvider(IdentityProvider):
 
 
 def get_kws_for_identity_type(identity_type):
+    SECRET = True
+    PLAINTEXT = False
+
     if identity_type == "rpc":
-        return ["eth_rpc_endpoint"]
+        return [("eth_rpc_endpoint", PLAINTEXT)]
     elif identity_type == "mnemonic":
-        return ["mnemonic"]
+        return [("mnemonic", SECRET)]
     elif identity_type == "key":
-        return ["private_key"]
+        return [("private_key", SECRET)]
     elif identity_type == "trezor":
         return []
     elif identity_type == "ledger":


### PR DESCRIPTION
Uses `getpass.getpass()` instead of `input()` so private key isn't shown on init.

When a user creates a new identity, they can omit secrets from the command line and be prompted for their key/mnemonic - this avoids the key being in their shell history.