### PR TITLE
Allow rpc call parameters to come from stdin or file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,35 +5,12 @@ SingularityNET CLI
 ## Getting Started  
   
 These instructions are intended to facilitate the development and use of the SingularityNET CLI.
-  
-### Prerequisites  
-  
-* [Python 3.6.5](https://www.python.org/downloads/release/python-365/)  
-* [Node 8+ w/npm](https://nodejs.org/en/download/)  
 
 ### Installing (For Use)
 
 * Install using pip
 ```bash
 $ pip install snet-cli
-```
-  
-### Installing (For Development)
-  
-* Clone the git repository  
-```bash  
-$ git clone git@github.com:singnet/snet-cli.git
-$ cd snet-cli
-```  
-  
-* Install development/test blockchain dependencies  
-```bash  
-$ ./scripts/blockchain install
-```
-  
-* Install the package in development/editable mode  
-```bash  
-$ pip install -e .
 ```
 
 ### Commands
@@ -215,7 +192,8 @@ snet client call METHOD PARAMS [--max-price MAX_PRICE]
 
 * Call a SingularityNET service
 * `METHOD`: service's target JSON-RPC method name
-* `PARAMS`: serialized JSON object containing target JSON-RPC method's parameters and call arguments
+* `PARAMS`: serialized JSON object containing target JSON-RPC method's parameters and call arguments (also accepts path
+of file containing serialized JSON parameters object; leave empty to read from stdin)
 * `MAX_PRICE`: skip interactive confirmation of job price if below this value
 * `AGENT_AT`: address of Agent contract associated with service; overwrites session `current_agent_at`
 * `JOB_AT`: address of Job contract instance; continue existing job from current state or create a new job if not
@@ -360,11 +338,38 @@ snet contract <ContractName> [--at AT] <functionName> PARAM1, PARAM2, ... [--tra
 
 ---
 
-## Release  
+## Development
+
+### Installing
+
+#### Prerequisites  
+  
+* [Python 3.6.5](https://www.python.org/downloads/release/python-365/)  
+* [Node 8+ w/npm](https://nodejs.org/en/download/)
+
+---
+
+* Clone the git repository  
+```bash  
+$ git clone git@github.com:singnet/snet-cli.git
+$ cd snet-cli
+```  
+  
+* Install development/test blockchain dependencies  
+```bash  
+$ ./scripts/blockchain install
+```
+  
+* Install the package in development/editable mode  
+```bash  
+$ pip install -e .
+```
+
+### Release  
   
 This project is published to [PyPI](https://pypi.org/project/snet-cli/).  
   
-## Versioning  
+### Versioning  
   
 We use [SemVer](http://semver.org/) for versioning. For the versions available, see the
 [tags on this repository](https://github.com/singnet/snet-cli/tags).   

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='snet-cli',
-    version='0.1.2',
+    version='0.1.3',
     packages=find_packages(),
     url='https://github.com/singnet/snet-cli',
     license='MIT',
@@ -10,18 +10,18 @@ setup(
     author_email='info@singularitynet.io',
     description='SingularityNET CLI',
     install_requires=[
-        'jsonrpcclient',
-        'web3',
-        'mnemonic',
-        'bip32utils',
-        'ecdsa',
-        'trezor',
+        'jsonrpcclient==2.5.2',
+        'web3==4.2.1',
+        'mnemonic==0.18',
+        'bip32utils==0.3.post3',
+        'ecdsa==0.13',
+        'trezor==0.9.1',
         'rlp==0.6.0',
-        'PyYAML',
+        'PyYAML==3.12',
         'hidapi>=0.7.99',  # _vendor/ledgerblue
         'protobuf>=2.6.1',  # _vendor/ledgerblue
-        'pycryptodome',  # _vendor/ledgerblue
-        'future',  # _vendor/ledgerblue
+        'pycryptodome==3.6.1',  # _vendor/ledgerblue
+        'future==0.16.0',  # _vendor/ledgerblue
         'ecpy>=0.8.1',  # _vendor/ledgerblue
         'pillow>=3.4.0',  # _vendor/ledgerblue
         'python-u2flib-host>=3.0.2'  # _vendor/ledgerblue

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -183,7 +183,9 @@ def add_client_options(parser):
     call_p = subparsers.add_parser("call", help="Call a service")
     call_p.set_defaults(fn="call")
     call_p.add_argument("method", help="target service's method name to call", metavar="METHOD")
-    call_p.add_argument("params", nargs='?', help="json-serialized parameters to pass to method", metavar="PARAMS")
+    call_p.add_argument("params", nargs='?', help="json-serialized parameters object or path containing "
+                                                  "json-serialized parameters object (leave emtpy to read from stdin)",
+                        metavar="PARAMS")
     call_p.add_argument("--max-price", type=int, default=0,
                         help="skip interactive confirmation of job price if below max price (defaults to 0)")
     add_contract_identity_arguments(call_p, [("agent", "agent_at"), ("job", "job_at")])

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -183,7 +183,7 @@ def add_client_options(parser):
     call_p = subparsers.add_parser("call", help="Call a service")
     call_p.set_defaults(fn="call")
     call_p.add_argument("method", help="target service's method name to call", metavar="METHOD")
-    call_p.add_argument("params", help="json-serialized parameters to pass to method", metavar="PARAMS")
+    call_p.add_argument("params", nargs='?', help="json-serialized parameters to pass to method", metavar="PARAMS")
     call_p.add_argument("--max-price", type=int, default=0,
                         help="skip interactive confirmation of job price if below max price (defaults to 0)")
     add_contract_identity_arguments(call_p, [("agent", "agent_at"), ("job", "job_at")])


### PR DESCRIPTION
params argument can be omitted, or specified as `-`, and it will read from the command line.

This is currently only really useful with `--no-confirm` and `--max-price` set, since otherwise the confirmation prompts will prevent piping data via stdin.

Closes #9 