### PR TITLE
Do not interactively create identity if first command is 'snet identi…

### DIFF
--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -297,7 +297,7 @@ def add_contract_identity_arguments(parser, names_and_destinations=(("", "at"),)
         h = "{} contract address".format(name)
         if destination != "at":
             h += " (defaults to session.default_{})".format(destination)
-        identity_g.add_argument("--{}at".format(arg_name), dest=destination,
+        identity_g.add_argument("--{}at".format(arg_name), dest=destination, type=type_converter("address"),
                                 metavar="{}ADDRESS".format(metavar_name.upper()),
                                 help=h)
 


### PR DESCRIPTION
…ty create'

This allows for easier programmatic use of snet cli (e.g. for pipeline tests). If the first command run after snet-cli installation is `snet identity create`, skip interactive creation of first identity.