### PR TITLE
Update `service publish` to re-publish when metadata in `service.json…

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,8 @@ snet service publish [NETWORK] [--no-register]
                                                                           
 ```
 
-* Publish the service's Agent contract; optionally specify a network
+* Publish the service to the network; creates Agent contract and ServiceRegistration if applicable, updates Agent
+contract and ServiceRegistration metadata with local state if applicable; optionally specify a network
 * `NETWORK`: name of network to use (either `mainnet`, `kovan`, `ropsten`, `rinkeby` or `eth-rpc-endpoint`)
 * `--no-register`: does not register the published service
 * `CONFIG`: specify a custom service.json file path
@@ -395,7 +396,8 @@ snet service publish eth-rpc-endpoint ETH_RPC_ENDPOINT [--no-register]
                                                                           
 ```
 
-* Publish the service's Agent contract using a target Ethereum JSON-RPC endpoint
+* Publish the service to the network; creates Agent contract and ServiceRegistration if applicable, updates Agent
+contract and ServiceRegistration metadata with local state if applicable; optionally specify a network
 * `ETH_RPC_ENDPOINT`: Ethereum JSON-RPC endpoint (network determined by endpoint)
 * `--no-register`: does not register the published service
 * `CONFIG`: specify a custom service.json file path
@@ -409,7 +411,7 @@ SingularityNET Foundation)
 ```
 snet service update [NETWORK] [--new-price NEW_PRICE]
                               [--new-endpoint NEW_ENDPOINT]
-                              [--add-tags TAGS [TAG1, TAG2, ...]]
+                              [--new-tags TAGS [TAG1, TAG2, ...]]
                               [--new-description NEW_DESCRIPTION]
                               [--config CONFIG]
                               [--agent-factory-at AGENT_FACTORY_ADDRESS]
@@ -421,7 +423,7 @@ snet service update [NETWORK] [--new-price NEW_PRICE]
 * `NETWORK`: name of network to use (either `mainnet`, `kovan`, `ropsten`, `rinkeby` or `eth-rpc-endpoint`)
 * `NEW_PRICE`: new price to call the service
 * `NEW_ENDPOINT`: new endpoint to call the service's API
-* `TAGS`: tags you want to add to the service registration
+* `TAGS`: new list of tags you want associated with the service registration
 * `NEW_DESCRIPTION`: new description for the service
 * `CONFIG`: specify a custom service.json file path
 * `REGISTRY_ADDRESS`: address of Registry contract (not required for networks on which Registry has been deployed by
@@ -432,7 +434,7 @@ SingularityNET Foundation)
 ```
 snet service update eth-rpc-endpoint ETH_RPC_ENDPOINT [--new-price NEW_PRICE]
                                                       [--new-endpoint NEW_ENDPOINT]
-                                                      [--add-tags TAGS [TAG1, TAG2, ...]]
+                                                      [--new-tags TAGS [TAG1, TAG2, ...]]
                                                       [--new-description NEW_DESCRIPTION]
                                                       [--config CONFIG]
                                                       [--agent-factory-at AGENT_FACTORY_ADDRESS]
@@ -444,7 +446,7 @@ snet service update eth-rpc-endpoint ETH_RPC_ENDPOINT [--new-price NEW_PRICE]
 * `ETH_RPC_ENDPOINT`: Ethereum JSON-RPC endpoint (network determined by endpoint)
 * `NEW_PRICE`: new price to call the service
 * `NEW_ENDPOINT`: new endpoint to call the service's API
-* `TAGS`: tags you want to add to the service registration
+* `TAGS`: new list of tags you want associated with the service registration
 * `NEW_DESCRIPTION`: new description for the service
 * `CONFIG`: specify a custom service.json file path
 * `REGISTRY_ADDRESS`: address of Registry contract (not required for networks on which Registry has been deployed by

--- a/snet_cli/utils.py
+++ b/snet_cli/utils.py
@@ -84,6 +84,8 @@ def type_converter(t):
     else:
         if "int" in t:
             return lambda x: web3.Web3.toInt(text=x)
+        elif "bytes32" in t:
+            return lambda x: web3.Web3.toBytes(text=x).ljust(32, b"\0") if not x.startswith("0x") else web3.Web3.toBytes(hexstr=x).ljust(32, b"\0")
         elif "byte" in t:
             return lambda x: web3.Web3.toBytes(text=x) if not x.startswith("0x") else web3.Web3.toBytes(hexstr=x)
         elif "address" in t:
@@ -124,14 +126,14 @@ def walk_imports(entry_path):
     return seen_paths
 
 
-def get_contract_dict(contract_name, contract_artifacts_root=Path(__file__).absolute().parent.joinpath("resources", "contracts")):
-    contract_dict = {}
+def get_contract_def(contract_name, contract_artifacts_root=Path(__file__).absolute().parent.joinpath("resources", "contracts")):
+    contract_def = {}
     with open(Path(__file__).absolute().parent.joinpath(contract_artifacts_root, "abi", "{}.json".format(contract_name))) as f:
-        contract_dict["abi"] = json.load(f)
+        contract_def["abi"] = json.load(f)
     if os.path.isfile(Path(__file__).absolute().parent.joinpath(contract_artifacts_root, "networks", "{}.json".format(contract_name))):
         with open(Path(__file__).absolute().parent.joinpath(contract_artifacts_root, "networks", "{}.json".format(contract_name))) as f:
-            contract_dict["networks"] = json.load(f)
-    return contract_dict
+            contract_def["networks"] = json.load(f)
+    return contract_def
 
 
 def read_temp_tar(f):


### PR DESCRIPTION
Update `service publish` to re-publish when metadata in `service.json` differs from that on the target network. Update `service update` to take `--new-tags` argument to allow users to specify complete list of tags rather than only tags to add. Cleanup `ContractCommand` invocations from within other commands. Various improvements/bugfixes.