### PR TITLE
Fix issue with pycryptodome dependencies rised by new eth-hash v0.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'hidapi>=0.7.99',  # _vendor/ledgerblue
         'protobuf>=2.6.1',  # _vendor/ledgerblue
         'pycryptodome==3.6.1',  # _vendor/ledgerblue
+        'eth-hash==0.1.4',  # the latest eth-hash v0.2.0 requires pycryptodome>=3.6.6,<4
         'future==0.16.0',  # _vendor/ledgerblue
         'ecpy>=0.8.1',  # _vendor/ledgerblue
         'pillow>=3.4.0',  # _vendor/ledgerblue


### PR DESCRIPTION
The new version of eth-hash v0.2.0 contains  "pycryptodome>=3.6.6,<4" dependency.
This breaks the snet running with exception:
`pkg_resources.ContextualVersionConflict: (pycryptodome 3.6.1 (/usr/local/lib/python3.6/dist-packages), Requirement.parse('pycryptodome<4,>=3.6.6; extra == "pycryptodome"'), {'eth-hash'})`

The fix explicitly adds the dependency to the previous eth-hash v.0.1.4 in the setup.py file which requires "pycryptodome>=3.5.1,<4".