### PR TITLE
#58 eth-typing v2.0.0 version conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     install_requires=[
         'grpcio-tools==1.14.1',
         'jsonrpcclient==2.5.2',
+        'eth-typing<2', # workaround until next version after eth-abi v2.0.0-beta.1 is released
         'web3==4.2.1',
         'mnemonic==0.18',
         'bip32utils==0.3.post3',


### PR DESCRIPTION
11 days ago eth-typing v2.0.0 was released.
There is the fix for the eth-abi dependency to use 'eth-typing<2' which has not been released yet.

The current fix adds a workaround to load eth-typing version less than 2.