### PR TITLE
Remove AlphaRegistry contract unpacking as it is outdated.

### DIFF
--- a/scripts/blockchain
+++ b/scripts/blockchain
@@ -16,8 +16,8 @@ def main():
     token_json_src_dir = node_modules_dir.joinpath("singularitynet-token-contracts")
     token_contract_name = "SingularityNetToken"
     contract_json_dest_dir = pathlib.Path(__file__).absolute().parent.parent.joinpath("snet_cli", "resources", "contracts")
-    abi_contract_names = ["Agent", "AgentFactory", "Job", "Registry", "AlphaRegistry"]
-    networks_contract_names = ["AgentFactory", "Registry", "AlphaRegistry"]
+    abi_contract_names = ["Agent", "AgentFactory", "Job", "Registry"]
+    networks_contract_names = ["AgentFactory", "Registry"]
 
     npm_location = shutil.which('npm')
     if not npm_location:


### PR DESCRIPTION
Fix platform-pipeline CI build https://circleci.com/gh/singnet/platform-pipeline/7 after PR https://github.com/singnet/platform-contracts/pull/33

NB: alpha-dapp also uses AlphaRegistry, but my opinion it should use ```npm``` packages to work with corresponding API. And we can migrate it to the latest API only when we get rid of using AlphaRegistry in alpha-dapp code.