### PR TITLE
Logging, --yes, check organization and tags before publish/update

### DIFF
--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -277,13 +277,15 @@ def add_service_options(parser, config):
     init_p.add_argument("--tags", nargs="+", metavar=("TAGS", "TAG1, TAG2,"), help="tags to describe the service (default: [])")
     init_p.add_argument("--description",
                         help='human-readable description of the service (default: "")')
-    init_p.add_argument("-y", action="store_true", help="accept defaults for any argument that is not provided")
+    init_p.add_argument("--yes", "-y", action="store_true", help="accept defaults for any argument that is not provided")
 
     network_names = list(
         map(lambda x: x[len("network."):], filter(lambda x: x.startswith("network."), config.sections())))
 
     publish_p = subparsers.add_parser("publish", help="Publish a service to the network", default_choice="default")
     publish_p.set_defaults(fn="publish")
+    publish_p.add_argument("--yes", "-y", action="store_true",
+                           help="skip interactive confirmation of service publish")
     networks_publish_subparsers = publish_p.add_subparsers(title="networks", metavar="[NETWORK]")
 
     for network_name in network_names:
@@ -301,6 +303,8 @@ def add_service_options(parser, config):
 
     update_p = subparsers.add_parser("update", help="Update a service on the network", default_choice="default")
     update_p.set_defaults(fn="update")
+    update_p.add_argument("--yes", "-y", action="store_true",
+                          help="skip interactive confirmation of service update")
     networks_update_subparsers = update_p.add_subparsers(title="networks", metavar="[NETWORK]")
 
     for network_name in network_names:
@@ -323,6 +327,8 @@ def add_service_options(parser, config):
     networks_update_subparsers = delete_p.add_subparsers(title="networks", metavar="[NETWORK]")
     delete_p.add_argument("organization", help="Name of the Organization", metavar="ORG_NAME")
     delete_p.add_argument("name", help="Name of the Service", metavar="SERVICE_NAME")
+    delete_p.add_argument("--yes", "-y", action="store_true",
+                          help="skip interactive confirmation of service delete")
 
     for network_name in network_names:
         p = networks_update_subparsers.add_parser(network_name,
@@ -453,7 +459,7 @@ def add_transaction_arguments(parser):
     transaction_g.add_argument("--wallet-index", type=int,
                                help="wallet index of account to use for signing (defaults to session.default_wallet"
                                     " index)")
-    transaction_g.add_argument("--no-confirm", action="store_true",
+    transaction_g.add_argument("--yes", "-y", action="store_true",
                                help="skip interactive confirmation of transaction payload", default=False)
     g = transaction_g.add_mutually_exclusive_group()
     g.add_argument("--verbose", "-v", action="store_true", help="verbose transaction printing", default=False)

--- a/snet_cli/commands.py
+++ b/snet_cli/commands.py
@@ -1094,7 +1094,14 @@ class ServiceCommand(BlockchainCommand):
                         self._error(e)
 
                 current_tags_set = set(current_tags)
-                new_tags_set = set([type_converter("bytes32")(tag) for tag in service_json["tags"]])
+                new_tags_set = []
+                # Each tag has a max length of 32 chars
+                for tag in service_json["tags"]:
+                    if len(tag) <= 32:
+                        new_tags_set.append(tag)
+                    else:
+                        self._printerr("Tag {} is too long! Removing...\n")
+                new_tags_set = set(new_tags_set)
 
                 if current_tags_set != new_tags_set:
                     remove_tags = current_tags_set - new_tags_set
@@ -1327,10 +1334,16 @@ class ServiceCommand(BlockchainCommand):
         if new_tags is None and "tags" in service_json:
             new_tags = service_json["tags"]
 
-        # Tags has a max length of 32 chars
-        if len(new_tags) <= 32:
+        if new_tags:
             current_tags_set = set(current_tags)
-            new_tags_set = set([type_converter("bytes32")(tag) for tag in new_tags])
+            # Each tag has a max length of 32 chars
+            new_tags_set = []
+            for tag in new_tags:
+                if len(tag) <= 32:
+                    new_tags_set.append(tag)
+                else:
+                    self._printerr("Tag {} is too long! Removing...\n")
+            new_tags_set = set(new_tags_set)
 
             if current_tags_set != new_tags_set:
                 remove_tags = current_tags_set - new_tags_set

--- a/snet_cli/config.py
+++ b/snet_cli/config.py
@@ -14,6 +14,10 @@ def persist():
 try:
     with open(_snet_folder.joinpath("config")) as f:
         conf.read_file(f)
+    # Looking for IPFS at snet-cli config file (required)
+    if "ipfs" not in conf:
+        conf["ipfs"] = {"default_ipfs_endpoint": "http://ipfs.singularitynet.io:80"}
+        persist()
 except FileNotFoundError:
     conf["network.kovan"] = {"default_eth_rpc_endpoint": "https://kovan.infura.io"}
     conf["network.mainnet"] = {"default_eth_rpc_endpoint": "https://mainnet.infura.io"}


### PR DESCRIPTION
- Logging on every `transact()` call. (Related #61)
- Add `--yes (-y)` to avoid user interaction at `service` commands. (#70)
- Change `--no-confirm` to `--yes (-y)` for transactions.
- `_service_json_parser()` checks if organization is valid and if user is a member|owner of it.
- Check the length of each tag (max 32 chars) before publish/update service.
- Check for `[ipfs]` at config file to avoid conflict with previous snet-cli versions.