### PR TITLE
add mpe_client_command with the first function: sing_message

### DIFF
--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -9,6 +9,7 @@ from snet_cli.commands import IdentityCommand, SessionCommand, NetworkCommand, C
 from snet_cli.identity import get_identity_types
 from snet_cli.session import get_session_keys
 from snet_cli.utils import type_converter, get_contract_def
+from snet_cli.mpe_client_command import MPEClientCommand
 
 
 class CustomParser(argparse.ArgumentParser):
@@ -82,6 +83,9 @@ def add_root_options(parser, config):
 
     organization_p = subparsers.add_parser("organization", help="Interact with SingularityNET Organizations")
     add_organization_options(organization_p)
+
+    mpe_client_p = subparsers.add_parser("mpe-client", help="Interact with SingularityNET services (using MultiPartyEscrow channels)")
+    add_mpe_client_options(mpe_client_p)
 
 
 def add_version_options(parser):
@@ -467,3 +471,17 @@ class AppendPositionalAction(argparse.Action):
             setattr(namespace, "contract_positional_inputs", [])
         getattr(namespace, "contract_positional_inputs").append(values)
         delattr(namespace, self.dest)
+
+def add_mpe_client_options(parser):
+    parser.set_defaults(cmd=MPEClientCommand)
+    subparsers = parser.add_subparsers(title="Commands", metavar="COMMAND")
+    subparsers.required = True
+    sign_message_p = subparsers.add_parser("sign_message", help="Sign the message for the given channel")
+    sign_message_p.set_defaults(fn="print_sign_message")
+    
+    # int is ok here because in python3 int is unlimited
+    sign_message_p.add_argument("mpe_address",          help="address of MPE contract")
+    sign_message_p.add_argument("channel_id", type=int, help="channel_id")
+    sign_message_p.add_argument("nonce",      type=int, help="nonce of the channel")
+    sign_message_p.add_argument("amount",     type=int, help="amount")
+                                                  

--- a/snet_cli/identity.py
+++ b/snet_cli/identity.py
@@ -60,7 +60,10 @@ class KeyIdentityProvider(IdentityProvider):
         else:
             h = defunct_hash_message(text=message.lower())
         return self.w3.eth.account.signHash(h, self.private_key).signature
-
+    
+    def sign_message_after_soliditySha3(self, message):
+        h = defunct_hash_message(message)
+        return self.w3.eth.account.signHash(h, self.private_key).signature
 
 class RpcIdentityProvider(IdentityProvider):
     def __init__(self, w3, index):
@@ -78,7 +81,8 @@ class RpcIdentityProvider(IdentityProvider):
             return self.w3.eth.sign(self.get_address(), hexstr=self.w3.sha3(hexstr=message).hex())
         else:
             return self.w3.eth.sign(self.get_address(), text=message.lower())
-
+    def sign_message_after_soliditySha3(self, message):
+        return self.w3.eth.sign(self.get_address(), message)
 
 class MnemonicIdentityProvider(IdentityProvider):
     def __init__(self, w3, mnemonic, index):

--- a/snet_cli/mpe_client_command.py
+++ b/snet_cli/mpe_client_command.py
@@ -1,0 +1,23 @@
+from snet_cli.commands import BlockchainCommand
+import base64
+
+
+class MPEClientCommand(BlockchainCommand):
+    def sign_message(self):
+        # here it is ok to accept address without checksum
+        mpe_address = self.w3.toChecksumAddress(self.args.mpe_address)
+        
+        message = self.w3.soliditySha3(
+        ["address",   "uint256",            "uint256",       "uint256"],
+        [mpe_address, self.args.channel_id, self.args.nonce, self.args.amount])
+        
+        sign = self.ident.sign_message_after_soliditySha3(message)
+        return sign
+    
+    def print_sign_message(self):
+        sign = self.sign_message()
+        print("signature hex: ")
+        print(sign.hex())
+        print("signature base64: ")
+        print(base64.b64encode(sign))
+        


### PR DESCRIPTION
The first function for mpe-client functionality: sign_message.
This function print signature for the claim message (see MultiPartyEscrow.sol in https://github.com/singnet/platform-contracts for details).

example: 
 snet mpe-client sign_message 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e 0 0 42  

(parameters : mpe_address, channel_id, nonce, amount)