### PR TITLE
add print_my_channels option for mpe-client

### DIFF
--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -488,8 +488,10 @@ def add_mpe_client_options(parser):
     def add_p_channel_id(p):
         # int is ok here because in python3 int is unlimited
         p.add_argument("channel_id", type=int, help="channel_id")
-    def add_p_full_message(p):
+    def add_p_mpe_address(p):
         p.add_argument("mpe_address",          help="address of MPE contract")
+    def add_p_full_message(p):
+        add_p_mpe_address(p)
         add_p_channel_id(p)
         p.add_argument("nonce",      type=int, help="nonce of the channel")
         p.add_argument("amount",     type=int, help="amount")
@@ -524,3 +526,10 @@ def add_mpe_client_options(parser):
     # "block_number":   get the most recent block number
     p = subparsers.add_parser("block_number", help="Get Low level function for calling the server")
     p.set_defaults(fn="print_block_number")
+
+    # "print_my_channels": print all channels which have the given idendity as a sender 
+    p = subparsers.add_parser("print_my_channels", help="Print all channels related to the current identity")
+    p.set_defaults(fn="print_my_channels")
+    add_p_mpe_address(p)
+    p.add_argument("--from_block", type=int, default=0, help="Start searching from this block")
+    

--- a/snet_cli/commands.py
+++ b/snet_cli/commands.py
@@ -136,7 +136,28 @@ class BlockchainCommand(Command):
                 args_dict["contract_named_input_{}".format(k)] = v
             return DefaultAttributeObject(**args_dict)
         return f
+    
+    def get_ContractCommand(self, contract_name, contract_address, contract_fn, contract_params, is_silent = True):
+        contract_def = get_contract_def(contract_name)
+        if (is_silent):
+            out_f = None
+        else:
+            out_f = self.err_f
+        return ContractCommand(config= self.config,
+                               args  = self.get_contract_argser(
+                                             contract_address  = contract_address,
+                                             contract_function = contract_fn,
+                                             contract_def      = contract_def)(*contract_params),
+                               out_f = out_f,
+                               err_f = out_f,
+                               w3    = self.w3,
+                               ident = self.ident)
 
+    def call_contract_command(self, contract_name, contract_address, contract_fn, contract_params, is_silent = True):
+        return self.get_ContractCommand(contract_name, contract_address, contract_fn, contract_params, is_silent).call()
+
+    def transact_contract_command(self, contract_name, contract_address, contract_fn, contract_params, is_silent = True):
+        return self.get_ContractCommand(contract_name, contract_address, contract_fn, contract_params, is_silent).transact()
 
 class InitCommand(Command):
     def init(self):

--- a/snet_cli/utils.py
+++ b/snet_cli/utils.py
@@ -183,3 +183,13 @@ def compile_proto(entry_path, codegen_dir, proto_file=None):
 
     except Exception as e:
         return False
+
+# return element of abi (return None if fails to find)
+def abi_get_element_by_name(abi, name):
+    for a in abi["abi"]:
+        if ("name" in a and a["name"] == name):
+            return a
+    return None
+
+def abi_decode_struct_to_dict(abi, struct_list):
+    return {el_abi["name"] : el for el_abi, el in zip(abi["outputs"], struct_list)}


### PR DESCRIPTION
Add print_my_channels option to mpe-client (print all channels which belongs to the client). This is the first element in stateless client logic.  
Moreover I've added helper function to class BlockchainCommand: call_contract_command and transact_contract_command. Using this functions we can remove all ugly "ContractCommand" calls. 