### PR TITLE
add display_name and encoding to service metadata

### DIFF
--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -585,21 +585,40 @@ def add_mpe_service_options(parser):
         p.add_argument("--tags", nargs="*", default=[], help="tags for service")
     def add_p_service_path_opt(p):
         p.add_argument("--service_path",  default="",  help="Registry path for the service (default \"\")")
-
     def add_p_endpoints_finalarg(p):
         p.add_argument("endpoints", nargs="+",  help="endpoints")
+    def add_p_display_name(p):
+        p.add_argument("display_name", help="Service display name")
+    def add_p_encoding(p):
+        p.add_argument("--encoding", default = "grcp", choices=['grpc', 'json'], help="Service encoding")
+    def add_p_protodir(p):
+        p.add_argument("protodir",     help="Directory which contains protobuf files")
 
+    
+                    
     
     # "publish protobuf in IPFS":
     p = subparsers.add_parser("publish_proto", help="Publish protobuf file(s) in IPFS")
     p.set_defaults(fn="publish_proto_in_ipfs")
-    p.add_argument("protodir",     help="Directory which contains protobuf files")
+    add_p_protodir(p)
     
-    p = subparsers.add_parser("metadata_init", help="Init metadata file")
+    
+    p = subparsers.add_parser("metadata_init", help="Init metadata file (with providing model_ipfs_hash, mpe_address, display_name and optionally encoding. Default enconding is grpc)")
     p.set_defaults(fn="metadata_init")
     add_p_metadata_file_opt(p)
     add_p_model_ipfs_hash(p)
     add_p_mpe_address(p)
+    add_p_display_name(p)
+    add_p_encoding(p)
+
+    p = subparsers.add_parser("publish_proto_metadata_init", help="Publish protobuf file(s) in IPFS and init metadata file (with providing mpe_address, display_name and optionally encoding. Default enconding is grpc)")
+    p.set_defaults(fn="publish_proto_metadata_init")
+    add_p_protodir(p)
+    add_p_metadata_file_opt(p)
+    add_p_mpe_address(p)
+    add_p_display_name(p)
+    add_p_encoding(p)
+                
 
     p = subparsers.add_parser("metadata_set_fixed_price", help="Set pricing model as fixed price for all methods")
     p.set_defaults(fn="metadata_set_fixed_price")
@@ -639,20 +658,6 @@ def add_mpe_service_options(parser):
     p = subparsers.add_parser("get_service_metadata", help="Get service metadata from registry")
     p.set_defaults(fn="get_service_metadata_hash_from_registry")
     add_p_registry_info(p)
-
-    p = subparsers.add_parser("publish_service_fixed_price_single_group", help="Publish service with fixed price, single group and multiply endpoints")
-    p.set_defaults(fn="publish_service_fixed_price_single_group")
-    p.add_argument("protodir",     help="Directory which contains protobuf files")    
-    add_p_registry_info(p)
-    add_p_mpe_address(p)
-    add_p_price(p)
-    add_p_payment_address(p)
-    add_p_endpoints_finalarg(p)
-    p.add_argument("--group_name", default="group1", help="unique name of the group (human readable), default is group1")
-    add_p_metadata_file_opt(p)
-    add_p_tags_opt(p)
-    add_p_service_path_opt(p)
-    add_p_transact_yes(p)
     
 
     

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -589,11 +589,21 @@ def add_mpe_service_options(parser):
         p.add_argument("endpoints", nargs="+",  help="endpoints")
     def add_p_display_name(p):
         p.add_argument("display_name", help="Service display name")
-    def add_p_encoding(p):
+    def add_p_encoding_opt(p):
         p.add_argument("--encoding", default = "grcp", choices=['grpc', 'json'], help="Service encoding")
+    def add_p_service_type_opt(p):
+        p.add_argument("--service_type", default = "grcp", choices=['grpc', 'jsonrpc', 'process'], help="Service type")
+    def add_p_payment_expiration_threshold_p(p):
+        p.add_argument("--payment_expiration_threshold", type=int, default = 40320, help="Service expiration threshold in blocks (default is 40320 ~ one week with 15s/block)")
     def add_p_protodir(p):
         p.add_argument("protodir",     help="Directory which contains protobuf files")
 
+    def add_p_metadata_init_basic(p):
+        add_p_mpe_address(p)
+        add_p_display_name(p)
+        add_p_encoding_opt(p)
+        add_p_service_type_opt(p)
+        add_p_payment_expiration_threshold_p(p)
     
                     
     
@@ -603,21 +613,17 @@ def add_mpe_service_options(parser):
     add_p_protodir(p)
     
     
-    p = subparsers.add_parser("metadata_init", help="Init metadata file (with providing model_ipfs_hash, mpe_address, display_name and optionally encoding. Default enconding is grpc)")
+    p = subparsers.add_parser("metadata_init", help="Init metadata file (with providing model_ipfs_hash, mpe_address, display_name and optionally encoding, service_type and payment_expiration_threshold)")
     p.set_defaults(fn="metadata_init")
     add_p_metadata_file_opt(p)
     add_p_model_ipfs_hash(p)
-    add_p_mpe_address(p)
-    add_p_display_name(p)
-    add_p_encoding(p)
-
-    p = subparsers.add_parser("publish_proto_metadata_init", help="Publish protobuf file(s) in IPFS and init metadata file (with providing mpe_address, display_name and optionally encoding. Default enconding is grpc)")
+    add_p_metadata_init_basic(p)
+    
+    p = subparsers.add_parser("publish_proto_metadata_init", help="Publish protobuf file(s) in IPFS and init metadata file (with providing mpe_address, display_name and optionally encoding, service_type and payment_expiration_threshold)")
     p.set_defaults(fn="publish_proto_metadata_init")
     add_p_protodir(p)
     add_p_metadata_file_opt(p)
-    add_p_mpe_address(p)
-    add_p_display_name(p)
-    add_p_encoding(p)
+    add_p_metadata_init_basic(p)
                 
 
     p = subparsers.add_parser("metadata_set_fixed_price", help="Set pricing model as fixed price for all methods")

--- a/snet_cli/mpe_service_command.py
+++ b/snet_cli/mpe_service_command.py
@@ -13,21 +13,23 @@ class MPEServiceCommand(BlockchainCommand):
         ipfs_hash_base58 = utils_ipfs.publish_proto_in_ipfs(self._get_ipfs_client(), self.args.protodir)
         self._printout(ipfs_hash_base58)
 
-    # Init metadata with providing model_ipfs_hash, mpe_address, display_name and encoding  
-    def _metadata_init(self, model_ipfs_hash, mpe_address, display_name, encoding, metadata_file):
+    # Init metadata with providing model_ipfs_hash (all other parameters are taken from self.args)  
+    def _metadata_init(self, model_ipfs_hash):
         metadata = mpe_service_metadata()
-        metadata.set_model_ipfs_hash(model_ipfs_hash)
-        metadata.set_mpe_address(mpe_address)
-        metadata.set_display_name(display_name)
-        metadata.set_encoding(encoding)
-        metadata.save(metadata_file)
+        metadata.set_simple_field("model_ipfs_hash",              model_ipfs_hash)
+        metadata.set_simple_field("mpe_address",                  self.args.mpe_address)
+        metadata.set_simple_field("display_name",                 self.args.display_name)
+        metadata.set_simple_field("encoding",                     self.args.encoding)
+        metadata.set_simple_field("service_type",                 self.args.service_type)
+        metadata.set_simple_field("payment_expiration_threshold", self.args.payment_expiration_threshold)        
+        metadata.save(self.args.metadata_file)
     
     def metadata_init(self):
-        self._metadata_init(self.args.model_ipfs_hash, self.args.mpe_address, self.args.display_name, self.args.encoding, self.args.metadata_file)
+        self._metadata_init(self.args.model_ipfs_hash)
     
     def publish_proto_metadata_init(self):
         ipfs_hash_base58 = utils_ipfs.publish_proto_in_ipfs(self._get_ipfs_client(), self.args.protodir)
-        self._metadata_init(ipfs_hash_base58, self.args.mpe_address, self.args.display_name, self.args.encoding, self.args.metadata_file)
+        self._metadata_init(ipfs_hash_base58)
         
     #  metadata set fixed price  
     def metadata_set_fixed_price(self):        

--- a/snet_cli/mpe_service_command.py
+++ b/snet_cli/mpe_service_command.py
@@ -12,13 +12,22 @@ class MPEServiceCommand(BlockchainCommand):
     def publish_proto_in_ipfs(self):
         ipfs_hash_base58 = utils_ipfs.publish_proto_in_ipfs(self._get_ipfs_client(), self.args.protodir)
         self._printout(ipfs_hash_base58)
-        
-    # Init metadata and set model_ipfs_hash  
-    def metadata_init(self):
+
+    # Init metadata with providing model_ipfs_hash, mpe_address, display_name and encoding  
+    def _metadata_init(self, model_ipfs_hash, mpe_address, display_name, encoding, metadata_file):
         metadata = mpe_service_metadata()
-        metadata.set_model_ipfs_hash(self.args.model_ipfs_hash)
-        metadata.set_mpe_address(self.args.mpe_address)
-        metadata.save(self.args.metadata_file)
+        metadata.set_model_ipfs_hash(model_ipfs_hash)
+        metadata.set_mpe_address(mpe_address)
+        metadata.set_display_name(display_name)
+        metadata.set_encoding(encoding)
+        metadata.save(metadata_file)
+    
+    def metadata_init(self):
+        self._metadata_init(self.args.model_ipfs_hash, self.args.mpe_address, self.args.display_name, self.args.encoding, self.args.metadata_file)
+    
+    def publish_proto_metadata_init(self):
+        ipfs_hash_base58 = utils_ipfs.publish_proto_in_ipfs(self._get_ipfs_client(), self.args.protodir)
+        self._metadata_init(ipfs_hash_base58, self.args.mpe_address, self.args.display_name, self.args.encoding, self.args.metadata_file)
         
     #  metadata set fixed price  
     def metadata_set_fixed_price(self):        
@@ -77,25 +86,3 @@ class MPEServiceCommand(BlockchainCommand):
     def get_service_metadata_hash_from_registry(self):
         self._printout(self._get_service_metadata_hash_from_registry(self.args.registry_address, self.args.organization, self.args.service))
         
-    # II. High level functions
-    def publish_service_fixed_price_single_group(self):
-        
-        # publish protobuf in ipfs
-        model_ipfs_hash = utils_ipfs.publish_proto_in_ipfs(self._get_ipfs_client(), self.args.protodir)
-        
-        # create service metadata
-        metadata = mpe_service_metadata()
-        metadata.set_model_ipfs_hash(model_ipfs_hash)
-        metadata.set_mpe_address(self.args.mpe_address)        
-        metadata.set_fixed_price(self.args.price)
-        metadata.add_group(self.args.group_name, self.args.payment_address)
-        
-        for endpoint in self.args.endpoints:            
-            metadata.add_endpoint(self.args.group_name, endpoint)
-            
-        # save metadata in the file
-        metadata.save(self.args.metadata_file)
-        
-        # publish service
-        self._publish_service_with_metadata(self.args.registry_address, self.args.organization, self.args.service, self.args.service_path, self.args.tags, self.args.metadata_file)
-            

--- a/snet_cli/mpe_service_metadata.py
+++ b/snet_cli/mpe_service_metadata.py
@@ -1,13 +1,15 @@
 # functions for manipulate with server.json file
 # metadata format:
 #----------------------------------------------------
-# version         - used to track format changes (current version is 1)
-# model_ipfs_hash - IPFS HASH to the .tar archive of protobuf service specification
-# mpe_address     - Address of MultiPartyEscrow contract. 
-#                   Client should use it exclusively for cross-checking of mpe_address, 
-#                        (because service can attack via mpe_address)
-#                   Daemon can use it directly if authenticity of metadata is confirmed
-# pricing {}      - Pricing model
+# version          - used to track format changes (current version is 1)
+# display_name     - Display name of the service
+# encoding         - Service encoding (json or grpc)
+# model_ipfs_hash  - IPFS HASH to the .tar archive of protobuf service specification
+# mpe_address      - Address of MultiPartyEscrow contract. 
+#                    Client should use it exclusively for cross-checking of mpe_address, 
+#                         (because service can attack via mpe_address)
+#                    Daemon can use it directly if authenticity of metadata is confirmed
+# pricing {}      -  Pricing model
 #          Possible pricing models:
 #          1. Fixed price
 #              price_model  - "fixed_price"
@@ -34,16 +36,24 @@ class mpe_service_metadata:
     # init with modelIPFSHash
     def __init__(self):
         self.m = {"version"        : 1,
+                  "display_name"   : "",
+                  "encoding"       : "grpc", # grpc by default
                   "model_ipfs_hash": "",
                   "mpe_address"    : "",
                   "pricing"        : {},
                   "groups"         : [],
                   "endpoints"      : []}
                   
-    
+
     def set_model_ipfs_hash(self, model_ipfs_hash):
         self.m["model_ipfs_hash"] = model_ipfs_hash
 
+    def set_display_name(self, display_name):
+        self.m["display_name"] = display_name
+
+    def set_encoding(self, encoding):
+        self.m["encoding"] = encoding 
+        
     def set_mpe_address(self, mpe_address):
         self.m["mpe_address"] = mpe_address
         

--- a/snet_cli/mpe_service_metadata.py
+++ b/snet_cli/mpe_service_metadata.py
@@ -4,6 +4,11 @@
 # version          - used to track format changes (current version is 1)
 # display_name     - Display name of the service
 # encoding         - Service encoding (json or grpc)
+# service_type     - Service type (grpc, jsonrpc or process)  
+# payment_expiration_threshold - Service will reject payments with expiration less
+#                                than current_block + payment_expiration_threshold.
+#                                This field should be used by the client with caution.
+#                                Client should not accept arbitrary payment_expiration_threshold
 # model_ipfs_hash  - IPFS HASH to the .tar archive of protobuf service specification
 # mpe_address      - Address of MultiPartyEscrow contract. 
 #                    Client should use it exclusively for cross-checking of mpe_address, 
@@ -38,24 +43,20 @@ class mpe_service_metadata:
         self.m = {"version"        : 1,
                   "display_name"   : "",
                   "encoding"       : "grpc", # grpc by default
+                  "service_type"   : "grpc", # grpc by default
+                  "payment_expiration_threshold" : 40320, # one week by default (15 sec block,  24*60*60*7/15) 
                   "model_ipfs_hash": "",
                   "mpe_address"    : "",
                   "pricing"        : {},
                   "groups"         : [],
                   "endpoints"      : []}
                   
-
-    def set_model_ipfs_hash(self, model_ipfs_hash):
-        self.m["model_ipfs_hash"] = model_ipfs_hash
-
-    def set_display_name(self, display_name):
-        self.m["display_name"] = display_name
-
-    def set_encoding(self, encoding):
-        self.m["encoding"] = encoding 
-        
-    def set_mpe_address(self, mpe_address):
-        self.m["mpe_address"] = mpe_address
+    
+    def set_simple_field(self, f, v):
+        if (f != "display_name" and f != "encoding" and f != "model_ipfs_hash" and f != "mpe_address" and
+            f != "service_type" and f != "payment_expiration_threshold"):
+                raise Exception("unknow field in mpe_service_metadata")
+        self.m[f] = v        
         
     def set_fixed_price(self, price):
         if (type(price) != int): 


### PR DESCRIPTION
This pull request does: 
* add display_name and encoding to service metadata
* add "snet mpe-service publish_proto_metadata_init" function which couple publish_proto and metadata_init
* remove "snet mpe-service publish_service_fixed_price_single_group" function because it became too complex to use

The procedure to publish the simple service with one endpoint is following:

```bash
# publish .proto in IPFS and initialize service_matadata.json 
snet mpe-service publish_proto_metadata_init  <protodir>  <mpe-address>  <service-dispaly-name>

# set fixed price (in service_matadata.json)
snet mpe-service metadata_set_fixed_price <fixed_price_in_cogs>

# add single payment group to service_matadata.json 
snet mpe-service metadata_add_group <group_name>  <payment_address>

# add endpoint to this group to service_matadata.json 
snet mpe-service metadata_add_endpoints <group_name>  <end_point>

# publish service in registry (using service_matadata.json ). Organization should be already created.
snet mpe-service publish_service <registry_address>  <organization> <service_name> -y
```