### PR TITLE
Run apt-get update to solve http://deb.debian.org/debian  404  Not Found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
     - run:
         name: Install tools
         command: |
+          sudo apt-get update
           sudo apt-get -y install libudev-dev libusb-1.0-0-dev
     - checkout
     - run:


### PR DESCRIPTION
Run apt-get update to solve 
```
Err:1 http://deb.debian.org/debian stretch/main amd64 libudev-dev amd64 232-25+deb9u4
  404  Not Found
```