### PR TITLE
Specifying Python version in scripts/blockchain

### DIFF
--- a/scripts/blockchain
+++ b/scripts/blockchain
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.6
 
 import os
 import pathlib


### PR DESCRIPTION
When trying to run "scripts/blockchain" from ubuntu having both Python3.5 and Python3.6 installed, Python3.5 is chosen by default. That results in a very generic error being returned. Specifying the Python version fixes the problem!