### PR TITLE
Fix for platform contracts v0.2.5

### DIFF
--- a/blockchain/package.json
+++ b/blockchain/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "singularitynet-platform-contracts": "https://github.com/singnet/platform-contracts/releases/download/v0.2.4/singularitynet-platform-contracts-0.2.4.tgz",
+    "singularitynet-platform-contracts": "https://github.com/singnet/platform-contracts/releases/download/v0.2.5/singularitynet-platform-contracts-0.2.5.tgz",
     "singularitynet-token-contracts": "2.0.0"
   }
 }

--- a/snet_cli/__init__.py
+++ b/snet_cli/__init__.py
@@ -3,7 +3,7 @@ import sys
 from snet_cli import arguments
 from snet_cli.config import Config
 
-__version__ = "0.1.8.1"
+__version__ = "0.1.9"
 
 
 def main():

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -131,7 +131,7 @@ def add_network_options(parser, config):
     p.set_defaults(fn="create")
     p.add_argument("network_name", help="name of network to create")
     p.add_argument("eth_rpc_endpoint", help="ethereum rpc endpoint")
-    p.add_argument("--default_gas_price", default=1000000000, type=int, help="default gas price for this network (in wei), default is 1000000000")
+    p.add_argument("--default-gas-price", default=1000000000, type=int, help="default gas price for this network (in wei), default is 1000000000")
     p.add_argument("--skip-check", action="store_true", help="skip check that eth_rpc_endpoint is valid")
 
 
@@ -333,7 +333,7 @@ def add_p_mpe_address_opt(p):
 
 
 def add_p_metadata_file_opt(p):
-    p.add_argument("--metadata_file", default="service_metadata.json", help="Service metadata json file (default service_metadata.json)")
+    p.add_argument("--metadata-file", default="service_metadata.json", help="Service metadata json file (default service_metadata.json)")
 
 
 def add_p_service_in_registry(p):
@@ -370,7 +370,7 @@ def add_mpe_client_options(parser):
     def add_p_open_channel_basic(p):
         p.add_argument("amount",         type=stragi2cogs, help="amount of AGI tokens to put in the new channel")
         p.add_argument("expiration",     type=int, help="expiration time (in blocks) for the new channel (one block ~ 15 seconds)")
-        p.add_argument("--group_name", default=None, help="name of payment group for which we want to open the channel. Parameter should be specified only for services with several payment groups")
+        p.add_argument("--group-name", default=None, help="name of payment group for which we want to open the channel. Parameter should be specified only for services with several payment groups")
         add_p_mpe_address_opt(p)
         add_transaction_arguments(p)
 
@@ -460,7 +460,7 @@ def add_mpe_client_options(parser):
     p = subparsers.add_parser("print_all_channels", help="Print all channels related to the current identity. It may take a long time.")
     p.set_defaults(fn="print_all_channels_my")
     add_p_mpe_address_opt(p)
-    p.add_argument("--from_block", type=int, default=0, help="Start searching from this block")
+    p.add_argument("--from-block", type=int, default=0, help="Start searching from this block")
 
     p = subparsers.add_parser("print_initialized_channels", help="Print initialized channels related to the current identity.")
     p.set_defaults(fn="print_initialized_channels_my")
@@ -485,12 +485,12 @@ def add_mpe_service_options(parser):
     add_p_mpe_address_opt(p)
     p.add_argument("display_name", help="Service display name")
     p.add_argument("payment_address", help="payment_address for the first payment group")
-    p.add_argument("--group_name", default="default_group", help="name of the first payment group")
+    p.add_argument("--group-name", default="default_group", help="name of the first payment group")
     p.add_argument("--encoding", default = "proto", choices=['proto', 'json'], help="Service encoding")
-    p.add_argument("--service_type", default = "grpc", choices=['grpc', 'jsonrpc', 'process'], help="Service type")
-    p.add_argument("--payment_expiration_threshold", type=int, default = 40320, help="Service expiration threshold in blocks (default is 40320 ~ one week with 15s/block)")
+    p.add_argument("--service-type", default = "grpc", choices=['grpc', 'jsonrpc', 'process'], help="Service type")
+    p.add_argument("--payment-expiration-threshold", type=int, default = 40320, help="Service expiration threshold in blocks (default is 40320 ~ one week with 15s/block)")
     p.add_argument("--endpoints", default=[], nargs='*', help="endpoints for the first group")
-    p.add_argument("--fixed_price",type=stragi2cogs, help="set fixed price in AGI token for all methods")
+    p.add_argument("--fixed-price",type=stragi2cogs, help="set fixed price in AGI token for all methods")
 
     p = subparsers.add_parser("metadata_set_fixed_price", help="Set pricing model as fixed price for all methods")
     p.set_defaults(fn="metadata_set_fixed_price")
@@ -506,7 +506,7 @@ def add_mpe_service_options(parser):
     p = subparsers.add_parser("metadata_add_endpoints", help="Add endpoints to the groups")
     p.set_defaults(fn="metadata_add_endpoints")
     p.add_argument("endpoints", nargs="+",  help="endpoints")
-    p.add_argument("--group_name", default=None, help="name of the payment group to which we want to add endpoints. Parameter should be specified in case of several payment groups")
+    p.add_argument("--group-name", default=None, help="name of the payment group to which we want to add endpoints. Parameter should be specified in case of several payment groups")
     add_p_metadata_file_opt(p)
 
     p = subparsers.add_parser("publish_in_ipfs", help="Publish metadata only in IPFS, without publising in Registry")

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -132,6 +132,7 @@ def add_network_options(parser, config):
     p.add_argument("network_name", help="name of network to create")
     p.add_argument("eth_rpc_endpoint", help="ethereum rpc endpoint")
     p.add_argument("--default_gas_price", default=1000000000, type=int, help="default gas price for this network (in wei), default is 1000000000")
+    p.add_argument("--skip-check", action="store_true", help="skip check that eth_rpc_endpoint is valid")
 
 
     network_names = config.get_all_networks_names()

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -180,63 +180,68 @@ def _add_organization_arguments(parser):
     add_contract_identity_arguments(parser, [("registry", "registry_at")])
 
 
+def add_p_org_id(p):
+    p.add_argument("org_id", help="Id of the Organization")
+
+
 def add_organization_options(parser):
     parser.set_defaults(cmd=OrganizationCommand)
 
     subparsers = parser.add_subparsers(title="organization commands", metavar="COMMAND")
     subparsers.required = True
 
-    p = subparsers.add_parser("list", help="List Organizations")
+    p = subparsers.add_parser("list", help="List of Organizations Ids")
     p.set_defaults(fn="list")
+    add_contract_identity_arguments(p, [("registry", "registry_at")])
+    add_eth_call_arguments(p)
+
+    p = subparsers.add_parser("list-org-names", help="List Organizations Names and Ids")
+    p.set_defaults(fn="list_orgnames")
     add_contract_identity_arguments(p, [("registry", "registry_at")])
     add_eth_call_arguments(p)
 
     p = subparsers.add_parser("info", help="Organization's Informations")
     p.set_defaults(fn="info")
-    p.add_argument("name", help="Name of the Organization", metavar="ORG_NAME")
+    add_p_org_id(p)
     add_contract_identity_arguments(p, [("registry", "registry_at")])
     add_eth_call_arguments(p)
 
-    org_create_p = subparsers.add_parser("create", help="Create an Organization")
-    org_create_p.set_defaults(fn="create")
-    org_create_p.add_argument("name", help="Name of the Organization", metavar="ORG_NAME")
-    org_create_p.add_argument("--members",
-                              help="List of members to be added to the organization",
-                              metavar="ORG_MEMBERS[]")
-    _add_organization_arguments(org_create_p)
+    p = subparsers.add_parser("create", help="Create an Organization")
+    p.set_defaults(fn="create")
+    p.add_argument("org_name", help="Name of the Organization", metavar="ORG_NAME")
+    p.add_argument("--org-id", default=None, help="Unique organization Id (by default random id is generated)")
 
-    org_delete_p = subparsers.add_parser("delete", help="Delete an Organization")
-    org_delete_p.set_defaults(fn="delete")
-    org_delete_p.add_argument("name", help="Name of the Organization", metavar="ORG_NAME")
-    _add_organization_arguments(org_delete_p)
+    p.add_argument("--members", help="List of members to be added to the organization", metavar="ORG_MEMBERS[]")
+    _add_organization_arguments(p)
+
+    p = subparsers.add_parser("delete", help="Delete an Organization")
+    p.set_defaults(fn="delete")
+    add_p_org_id(p)
+    _add_organization_arguments(p)
 
     p = subparsers.add_parser("list-services", help="List Organization's services")
     p.set_defaults(fn="list_services")
-    p.add_argument("name", help="Name of the Organization", metavar="ORG_NAME")
+    add_p_org_id(p)
     add_contract_identity_arguments(p, [("registry", "registry_at")])
     add_eth_call_arguments(p)
 
-    org_change_owner_p = subparsers.add_parser("change-owner", help="Change Organization's owner")
-    org_change_owner_p.set_defaults(fn="change_owner")
-    org_change_owner_p.add_argument("name", help="Name of the Organization", metavar="ORG_NAME")
-    org_change_owner_p.add_argument("owner", help="Address of the new Organization's owner", metavar="OWNER_ADDRESS")
-    _add_organization_arguments(org_change_owner_p)
+    p = subparsers.add_parser("change-owner", help="Change Organization's owner")
+    p.set_defaults(fn="change_owner")
+    add_p_org_id(p)
+    p.add_argument("owner", help="Address of the new Organization's owner", metavar="OWNER_ADDRESS")
+    _add_organization_arguments(p)
 
-    org_add_members_p = subparsers.add_parser("add-members", help="Add members to Organization")
-    org_add_members_p.set_defaults(fn="add_members")
-    org_add_members_p.add_argument("name", help="Name of the Organization", metavar="ORG_NAME")
-    org_add_members_p.add_argument("members",
-                                   help="List of members to be added to the organization",
-                                   metavar="ORG_MEMBERS[]")
-    _add_organization_arguments(org_add_members_p)
+    p = subparsers.add_parser("add-members", help="Add members to Organization")
+    p.set_defaults(fn="add_members")
+    add_p_org_id(p)
+    p.add_argument("members", help="List of members to be added to the organization", metavar="ORG_MEMBERS[]")
+    _add_organization_arguments(p)
 
-    org_rm_members_p = subparsers.add_parser("rem-members", help="Remove members from Organization")
-    org_rm_members_p.set_defaults(fn="rem_members")
-    org_rm_members_p.add_argument("name", help="Name of the Organization", metavar="ORG_NAME")
-    org_rm_members_p.add_argument("members",
-                                  help="List of members to be removed from the organization",
-                                  metavar="ORG_MEMBERS[]")
-    _add_organization_arguments(org_rm_members_p)
+    p = subparsers.add_parser("rem-members", help="Remove members from Organization")
+    p.set_defaults(fn="rem_members")
+    add_p_org_id(p)
+    p.add_argument("members", help="List of members to be removed from the organization", metavar="ORG_MEMBERS[]")
+    _add_organization_arguments(p)
 
 
 def add_contract_function_options(parser, contract_name):
@@ -327,8 +332,8 @@ def add_p_metadata_file_opt(p):
 
 def add_p_service_in_registry(p):
     p.add_argument("--registry-at", "--registry", default=None, help="address of Registry contract, if not specified we read address from \"networks\"")
-    p.add_argument("organization", help="Name of organization")
-    p.add_argument("service",      help="Name of service")
+    add_p_org_id(p)
+    p.add_argument("service_id",      help="Id of service")
 
 
 def add_mpe_client_options(parser):
@@ -339,14 +344,14 @@ def add_mpe_client_options(parser):
     def add_p_channel_id(p):
         # int is ok here because in python3 int is unlimited
         p.add_argument("channel_id", type=int, help="channel_id")
-    def add_p_endpoint(p):        
+    def add_p_endpoint(p):
         p.add_argument("endpoint",             help="service endpoint")
     def add_p_full_service_for_call(p):
         add_p_endpoint(p)
         p.add_argument("--service", default=None, help="name of protobuf service to call. It should be specified in case of method name conflict.")
         p.add_argument("method",                  help="target service's method name to call")
         p.add_argument("params", nargs='?',       help="json-serialized parameters object or path containing "
-                                                "json-serialized parameters object (leave emtpy to read from stdin)")        
+                                                "json-serialized parameters object (leave emtpy to read from stdin)")
     def add_p_full_message(p):
         add_p_mpe_address_opt(p)
         add_p_channel_id(p)
@@ -415,7 +420,7 @@ def add_mpe_client_options(parser):
     p.set_defaults(fn="open_init_channel_from_registry")
     add_p_service_in_registry(p)
     add_p_open_channel_basic(p)
-    
+
     p = subparsers.add_parser("channel_claim_timeout", help="Claim timeout of the channel")
     p.set_defaults(fn="channel_claim_timeout")
     add_p_channel_id(p)
@@ -435,14 +440,14 @@ def add_mpe_client_options(parser):
     p.set_defaults(fn="call_server_statelessly")
     add_p_channel_id(p)
     p.add_argument("price",     type=stragi2cogs, help="price for this call in AGI tokens")
-    add_p_full_service_for_call(p)                                                
+    add_p_full_service_for_call(p)
     add_p_mpe_address_opt(p)
-    
+
     p = subparsers.add_parser("call_lowlevel", help="Low level function for calling the server. Channel should be already initialized.")
     p.set_defaults(fn="call_server_lowlevel")
     add_p_full_message(p)
     add_p_full_service_for_call(p)
-    
+
     p = subparsers.add_parser("block_number", help="Print the last ethereum block number")
     p.set_defaults(fn="print_block_number")
 
@@ -466,7 +471,7 @@ def add_mpe_service_options(parser):
     parser.set_defaults(cmd=MPEServiceCommand)
     subparsers = parser.add_subparsers(title="Commands", metavar="COMMAND")
     subparsers.required = True
-    
+
     def add_p_protodir(p):
         p.add_argument("protodir",     help="Directory which contains protobuf files")
 
@@ -492,13 +497,13 @@ def add_mpe_service_options(parser):
     add_p_metadata_file_opt(p)
     p.add_argument("group_name", help="name of the new payment group")
     p.add_argument("payment_address", help="payment_address for this group")
- 
+
     p = subparsers.add_parser("metadata_add_endpoints", help="Add endpoints to the groups")
     p.set_defaults(fn="metadata_add_endpoints")
     p.add_argument("endpoints", nargs="+",  help="endpoints")
     p.add_argument("--group_name", default=None, help="name of the payment group to which we want to add endpoints. Parameter should be specified in case of several payment groups")
     add_p_metadata_file_opt(p)
- 
+
     p = subparsers.add_parser("publish_in_ipfs", help="Publish metadata only in IPFS, without publising in Registry")
     p.set_defaults(fn="publish_metadata_in_ipfs")
     add_p_metadata_file_opt(p)

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -200,6 +200,11 @@ def add_organization_options(parser):
     add_contract_identity_arguments(p, [("registry", "registry_at")])
     add_eth_call_arguments(p)
 
+    p = subparsers.add_parser("list-my", help="Print organization which has the current identity as the owner or as a member")
+    p.set_defaults(fn="list_my")
+    add_contract_identity_arguments(p, [("registry", "registry_at")])
+    add_eth_call_arguments(p)
+
     p = subparsers.add_parser("info", help="Organization's Informations")
     p.set_defaults(fn="info")
     add_p_org_id(p)

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -453,7 +453,7 @@ def add_mpe_channel_options(parser):
     add_p_mpe_address_opt(p)
     add_transaction_arguments(p)
 
-    p = subparsers.add_parser("extend-add", help="Set new exporation for the channel and add funds")
+    p = subparsers.add_parser("extend-add", help="Set new expiration for the channel and add funds")
     p.set_defaults(fn="channel_extend_and_add_funds")
     add_p_channel_id(p)
     expiration_amount_g = p.add_argument_group(title="Expiration and amount")

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -413,6 +413,7 @@ def add_p_group_name(p):
 def add_p_open_channel_basic(p):
     p.add_argument("amount",         type=stragi2cogs, help="amount of AGI tokens to put in the new channel")
     p.add_argument("expiration",     type=int, help="expiration time (in blocks) for the new channel (one block ~ 15 seconds)")
+    p.add_argument("--signer", default=None, help="Signer for the channel (by default is equal to the sender)")
     add_p_group_name(p)
     add_p_mpe_address_opt(p)
     add_transaction_arguments(p)

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -209,8 +209,9 @@ def add_organization_options(parser):
     p = subparsers.add_parser("create", help="Create an Organization")
     p.set_defaults(fn="create")
     p.add_argument("org_name", help="Name of the Organization", metavar="ORG_NAME")
-    p.add_argument("--org-id", default=None, help="Unique organization Id (by default random id is generated)")
-
+    pm = p.add_mutually_exclusive_group(required=True)
+    pm.add_argument("--org-id", default=None, help="Unique organization Id")
+    pm.add_argument("--auto",   action='store_true', help="Generate organization Id (by default random id is generated)")
     p.add_argument("--members", help="List of members to be added to the organization", metavar="ORG_MEMBERS[]")
     _add_organization_arguments(p)
 

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -489,6 +489,8 @@ def add_mpe_service_options(parser):
     p.add_argument("--encoding", default = "proto", choices=['proto', 'json'], help="Service encoding")
     p.add_argument("--service_type", default = "grpc", choices=['grpc', 'jsonrpc', 'process'], help="Service type")
     p.add_argument("--payment_expiration_threshold", type=int, default = 40320, help="Service expiration threshold in blocks (default is 40320 ~ one week with 15s/block)")
+    p.add_argument("--endpoints", default=[], nargs='*', help="endpoints for the first group")
+    p.add_argument("--fixed_price",type=stragi2cogs, help="set fixed price in AGI token for all methods")
 
     p = subparsers.add_parser("metadata_set_fixed_price", help="Set pricing model as fixed price for all methods")
     p.set_defaults(fn="metadata_set_fixed_price")

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -478,12 +478,9 @@ def add_mpe_service_options(parser):
     subparsers = parser.add_subparsers(title="Commands", metavar="COMMAND")
     subparsers.required = True
 
-    def add_p_protodir(p):
-        p.add_argument("protodir",     help="Directory which contains protobuf files")
-
     p = subparsers.add_parser("metadata_init", help="Init metadata file with providing protobuf directory (which we publish in IPFS) and display_name (optionally encoding, service_type and payment_expiration_threshold)")
     p.set_defaults(fn="publish_proto_metadata_init")
-    add_p_protodir(p)
+    p.add_argument("protodir",     help="Directory which contains protobuf files")
     add_p_metadata_file_opt(p)
     add_p_mpe_address_opt(p)
     p.add_argument("display_name", help="Service display name")
@@ -546,6 +543,19 @@ def add_mpe_service_options(parser):
     p = subparsers.add_parser("print_tags", help="Print tags for given service from registry")
     p.set_defaults(fn="print_service_tags_from_registry")
     add_p_service_in_registry(p)
+
+    def add_p_protodir_to_extract(p):
+        p.add_argument("protodir",     help="Directory to which extract api (model)")
+
+    p = subparsers.add_parser("get_api_metadata", help="Extract service api (model) to the given protodir. Get model_ipfs_hash from metadata")
+    p.set_defaults(fn="extract_service_api_from_metadata")
+    add_p_protodir_to_extract(p)
+    add_p_metadata_file_opt(p)
+
+    p = subparsers.add_parser("get_api_registry", help="Extract service api (model) to the given protodir. Get metadata from registry")
+    p.set_defaults(fn="extract_service_api_from_registry")
+    add_p_service_in_registry(p)
+    add_p_protodir_to_extract(p)
 
     p = subparsers.add_parser("delete", help="Delete service registration from registry")
     p.set_defaults(fn="delete_service_registration")

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -8,6 +8,7 @@ from snet_cli.commands import IdentityCommand, SessionCommand, NetworkCommand, C
 from snet_cli.identity import get_identity_types
 from snet_cli.utils import type_converter, get_contract_def
 from snet_cli.mpe_client_command  import MPEClientCommand
+from snet_cli.mpe_account_command  import MPEAccountCommand
 from snet_cli.mpe_service_command import MPEServiceCommand
 from snet_cli.utils_agi2cogs import stragi2cogs
 from snet_cli.config import get_session_keys, get_session_network_keys_removable
@@ -72,6 +73,8 @@ def add_root_options(parser, config):
     organization_p = subparsers.add_parser("organization", help="Interact with SingularityNET Organizations")
     add_organization_options(organization_p)
 
+    p = subparsers.add_parser("account", help="AGI account")
+    add_mpe_account_options(p)
     mpe_client_p = subparsers.add_parser("client", help="Interact with SingularityNET services")
     add_mpe_client_options(mpe_client_p)
 
@@ -342,39 +345,15 @@ def add_p_service_in_registry(p):
     p.add_argument("service_id",      help="Id of service")
 
 
-def add_mpe_client_options(parser):
-    parser.set_defaults(cmd=MPEClientCommand)
+def add_mpe_account_options(parser):
+    parser.set_defaults(cmd=MPEAccountCommand)
     subparsers = parser.add_subparsers(title="Commands", metavar="COMMAND")
     subparsers.required = True
-
-    def add_p_channel_id(p):
-        # int is ok here because in python3 int is unlimited
-        p.add_argument("channel_id", type=int, help="channel_id")
-    def add_p_endpoint(p):
-        p.add_argument("endpoint",             help="service endpoint")
-    def add_p_full_service_for_call(p):
-        add_p_endpoint(p)
-        p.add_argument("--service", default=None, help="name of protobuf service to call. It should be specified in case of method name conflict.")
-        p.add_argument("method",                  help="target service's method name to call")
-        p.add_argument("params", nargs='?',       help="json-serialized parameters object or path containing "
-                                                "json-serialized parameters object (leave emtpy to read from stdin)")
-    def add_p_full_message(p):
-        add_p_mpe_address_opt(p)
-        add_p_channel_id(p)
-        p.add_argument("nonce",      type=int, help="nonce of the channel")
-        p.add_argument("amount",     type=int, help="amount")
 
     def add_p_snt_address_opt(p):
         p.add_argument("--singularitynettoken-at", "--snt", default=None,  help="address of SingularityNetToken contract, if not specified we read address from \"networks\"")
 
-    def add_p_open_channel_basic(p):
-        p.add_argument("amount",         type=stragi2cogs, help="amount of AGI tokens to put in the new channel")
-        p.add_argument("expiration",     type=int, help="expiration time (in blocks) for the new channel (one block ~ 15 seconds)")
-        p.add_argument("--group-name", default=None, help="name of payment group for which we want to open the channel. Parameter should be specified only for services with several payment groups")
-        add_p_mpe_address_opt(p)
-        add_transaction_arguments(p)
-
-    p = subparsers.add_parser("account", help="print the currect ETH account")
+    p = subparsers.add_parser("print", help="print the currect ETH account")
     p.set_defaults(fn="print_account")
     add_eth_call_arguments(p)
 
@@ -404,6 +383,36 @@ def add_mpe_client_options(parser):
     p.add_argument("amount",   type=stragi2cogs, help="amount of AGI tokens to be transfered to another account inside MPE wallet")
     add_p_mpe_address_opt(p)
     add_transaction_arguments(p)
+
+
+def add_mpe_client_options(parser):
+    parser.set_defaults(cmd=MPEClientCommand)
+    subparsers = parser.add_subparsers(title="Commands", metavar="COMMAND")
+    subparsers.required = True
+
+    def add_p_channel_id(p):
+        # int is ok here because in python3 int is unlimited
+        p.add_argument("channel_id", type=int, help="channel_id")
+    def add_p_endpoint(p):
+        p.add_argument("endpoint",             help="service endpoint")
+    def add_p_full_service_for_call(p):
+        add_p_endpoint(p)
+        p.add_argument("--service", default=None, help="name of protobuf service to call. It should be specified in case of method name conflict.")
+        p.add_argument("method",                  help="target service's method name to call")
+        p.add_argument("params", nargs='?',       help="json-serialized parameters object or path containing "
+                                                "json-serialized parameters object (leave emtpy to read from stdin)")
+    def add_p_full_message(p):
+        add_p_mpe_address_opt(p)
+        add_p_channel_id(p)
+        p.add_argument("nonce",      type=int, help="nonce of the channel")
+        p.add_argument("amount",     type=int, help="amount")
+
+    def add_p_open_channel_basic(p):
+        p.add_argument("amount",         type=stragi2cogs, help="amount of AGI tokens to put in the new channel")
+        p.add_argument("expiration",     type=int, help="expiration time (in blocks) for the new channel (one block ~ 15 seconds)")
+        p.add_argument("--group-name", default=None, help="name of payment group for which we want to open the channel. Parameter should be specified only for services with several payment groups")
+        add_p_mpe_address_opt(p)
+        add_transaction_arguments(p)
 
     p = subparsers.add_parser("init_channel_metadata", help="Initialize channel using service metadata")
     p.set_defaults(fn="init_channel_from_metadata")

--- a/snet_cli/commands.py
+++ b/snet_cli/commands.py
@@ -196,9 +196,11 @@ class NetworkCommand(Command):
             self._pprint({network_section[len("network."):]: {k: v for k, v in network.items()}})
 
     def create(self):
-        # check endpoint by getting its network_id
-        w3         = get_web3(self.args.eth_rpc_endpoint)
-        network_id = w3.version.network
+        network_id = None
+        if (not self.args.skip_check):
+            # check endpoint by getting its network_id
+            w3         = get_web3(self.args.eth_rpc_endpoint)
+            network_id = w3.version.network
 
         self._printout("add network with name='%s' with networkId='%s'"%(self.args.network_name, str(network_id)))
         self.config.add_network(self.args.network_name, self.args.eth_rpc_endpoint, self.args.default_gas_price)

--- a/snet_cli/commands.py
+++ b/snet_cli/commands.py
@@ -312,7 +312,7 @@ class OrganizationCommand(BlockchainCommand):
         for idx, org_id in enumerate(org_list):
             rez = self.call_contract_command("Registry", "getOrganizationById", [org_id])
             if (not rez[0]):
-                raise Exception("Internal Error in Registry");
+                raise Exception("Organization was removed during this call. Please retry.");
             org_name = rez[2]
             self._printout("%s  %s"%(org_name, bytes32_to_str(org_id)))
 
@@ -456,3 +456,31 @@ class OrganizationCommand(BlockchainCommand):
         except Exception as e:
             self._printerr("\nTransaction error!\nHINT: Check if you are the owner of {}\n".format(org_id))
             raise
+
+    # find organization with have the current identity as the owner or as the membmer
+    def list_my(self):
+        org_list = self.call_contract_command("Registry", "listOrganizations", [])
+
+        rez_owner  = []
+        rez_member = []
+        for idx, org_id in enumerate(org_list):
+            (found, org_id, org_name, owner, members, serviceNames, repositoryNames) = self.call_contract_command("Registry", "getOrganizationById", [org_id])
+            if (not found):
+                raise Exception("Organization was removed during this call. Please retry.");
+            if self.ident.address == owner:
+                rez_owner.append((org_name, bytes32_to_str(org_id)))
+
+            if self.ident.address in members:
+                rez_member.append((org_name, bytes32_to_str(org_id)))
+
+        if (rez_owner):
+            self._printout("# Organizations you are the owner of")
+            self._printout("# OrgName OrgId")
+            for n,i in rez_owner:
+                self._printout("%s   %s"%(n,i))
+
+        if (rez_member):
+            self._printout("# Organizations you are the member of")
+            self._printout("# OrgName OrgId")
+            for n,i in rez_member:
+                self._printout("%s   %s"%(n,i))

--- a/snet_cli/commands.py
+++ b/snet_cli/commands.py
@@ -325,7 +325,7 @@ class OrganizationCommand(BlockchainCommand):
     def info(self):
         org_id = self.args.org_id
         (found, org_id, org_name, owner, members, serviceNames, repositoryNames) = self._getorganizationbyid(org_id)
-        self.error_organization_not_found(org_id, found)
+        self.error_organization_not_found(self.args.org_id, found)
 
         self._printout("\nOrganization Name:\n - %s"%org_name)
         self._printout("\nOrganization Id:\n - %s"%bytes32_to_str(org_id))

--- a/snet_cli/commands.py
+++ b/snet_cli/commands.py
@@ -286,7 +286,7 @@ class OrganizationCommand(BlockchainCommand):
     def _getorganizationbyid(self, org_id):
         org_id_bytes32 = type_converter("bytes32")(org_id)
         if (len(org_id_bytes32) > 32):
-            raise Exception("Your org_id is too long: len(org_id_bytes32)=%i"%(len(org_id_bytes32)))
+            raise Exception("Your org_id is too long, it should be 32 bytes or less. len(org_id_bytes32)=%i"%(len(org_id_bytes32)))
         return self.call_contract_command("Registry", "getOrganizationById", [org_id_bytes32])
 
     #TODO: It would be better to have standard nargs="+" in argparse for members.
@@ -363,7 +363,6 @@ class OrganizationCommand(BlockchainCommand):
 
     def delete(self):
         org_id = self.args.org_id
-        print(org_id)
         # Check if Organization exists
         (found,_,org_name,_,_,_,_) = self._getorganizationbyid(org_id)
         self.error_organization_not_found(org_id, found)
@@ -413,7 +412,6 @@ class OrganizationCommand(BlockchainCommand):
         self.error_organization_not_found(org_id, found)
 
         members = [member.lower() for member in members]
-        print(members)
         add_members = []
         for add_member in self.get_members_from_args():
             if add_member.lower() in members:

--- a/snet_cli/commands.py
+++ b/snet_cli/commands.py
@@ -124,8 +124,10 @@ class BlockchainCommand(Command):
         contract_def = get_contract_def(contract_name)
         if (is_silent):
             out_f = None
+            err_f = None
         else:
             out_f = self.out_f
+            err_f = self.err_f
         return ContractCommand(config= self.config,
                                args  = self.get_contract_argser(
                                              contract_address  = contract_address,
@@ -133,7 +135,7 @@ class BlockchainCommand(Command):
                                              contract_def      = contract_def,
                                              contract_name     = contract_name)(*contract_params),
                                out_f = out_f,
-                               err_f = out_f,
+                               err_f = err_f,
                                w3    = self.w3,
                                ident = self.ident)
 

--- a/snet_cli/commands.py
+++ b/snet_cli/commands.py
@@ -9,10 +9,9 @@ import yaml
 from rfc3986 import urlparse
 
 from snet_cli.contract import Contract
-from snet_cli.identity import get_kws_for_identity_type, get_identity_types
+from snet_cli.identity import get_kws_for_identity_type
 from snet_cli.utils import DefaultAttributeObject, get_web3, serializable, type_converter, get_contract_def, get_cli_version, bytes32_to_str
 
-from snet_cli.config import get_session_identity_keys, get_session_network_keys
 from snet_cli.utils_config import get_contract_address, get_field_from_args_or_session
 from snet_cli.identity import RpcIdentityProvider, MnemonicIdentityProvider, TrezorIdentityProvider, \
     LedgerIdentityProvider, KeyIdentityProvider

--- a/snet_cli/mpe_account_command.py
+++ b/snet_cli/mpe_account_command.py
@@ -1,0 +1,39 @@
+from snet_cli.commands import BlockchainCommand
+from snet_cli.utils_agi2cogs import cogs2stragi
+
+
+class MPEAccountCommand(BlockchainCommand):
+
+    def print_account(self):
+        self._printout(self.ident.address)
+
+    # print balance of ETH, AGI, and MPE wallet
+    def print_agi_and_mpe_balances(self):
+        if (self.args.account):
+            account = self.args.account
+        else:
+            account = self.ident.address
+        eth_wei  = self.w3.eth.getBalance(account)
+        agi_cogs = self.call_contract_command("SingularityNetToken", "balanceOf", [account])
+        mpe_cogs = self.call_contract_command("MultiPartyEscrow",    "balances",  [account])
+
+        # we cannot use _pprint here because it doesn't conserve order yet
+        self._printout("    account: %s"%account)
+        self._printout("    ETH: %s"%self.w3.fromWei(eth_wei, 'ether'))
+        self._printout("    AGI: %s"%cogs2stragi(agi_cogs))
+        self._printout("    MPE: %s"%cogs2stragi(mpe_cogs))
+
+    def deposit_to_mpe(self):
+        amount      = self.args.amount
+        mpe_address = self.get_mpe_address()
+
+        already_approved = self.call_contract_command("SingularityNetToken", "allowance", [self.ident.address, mpe_address])
+        if (already_approved < amount):
+            self.transact_contract_command("SingularityNetToken", "approve", [mpe_address, amount])
+        self.transact_contract_command("MultiPartyEscrow", "deposit", [amount])
+
+    def withdraw_from_mpe(self):
+        self.transact_contract_command("MultiPartyEscrow", "withdraw", [self.args.amount])
+
+    def transfer_in_mpe(self):
+        self.transact_contract_command("MultiPartyEscrow", "transfer", [self.args.receiver, self.args.amount])

--- a/snet_cli/mpe_channel_command.py
+++ b/snet_cli/mpe_channel_command.py
@@ -100,7 +100,12 @@ class MPEChannelCommand(MPEServiceCommand):
         group_id    = metadata.get_group_id(self.args.group_name)
         recipient   = metadata.get_payment_address(self.args.group_name)
 
-        channel_info = {"sender": self.ident.address, "signer": self.ident.address, "recipient": recipient, "groupId" : group_id}
+        if (self.args.signer):
+            signer = self.args.signer
+        else:
+            signer = self.ident.address
+
+        channel_info = {"sender": self.ident.address, "signer": signer, "recipient": recipient, "groupId" : group_id}
         params = [channel_info["signer"], channel_info["recipient"], channel_info["groupId"], self.args.amount, self.args.expiration]
         rez = self.transact_contract_command("MultiPartyEscrow", "openChannel", params)
 

--- a/snet_cli/mpe_channel_command.py
+++ b/snet_cli/mpe_channel_command.py
@@ -1,0 +1,235 @@
+from snet_cli.mpe_service_command import MPEServiceCommand
+from snet_cli.utils import compile_proto
+import base64
+from pathlib import Path
+import os
+from snet_cli.utils import get_contract_def, abi_get_element_by_name, abi_decode_struct_to_dict
+from snet_cli.mpe_service_metadata import load_mpe_service_metadata
+from snet_cli.utils_ipfs import safe_extract_proto_from_ipfs
+import shutil
+import tempfile
+from snet_cli.utils_agi2cogs import cogs2stragi
+import pickle
+from snet_cli.contract import Contract
+
+# we inherit MPEServiceCommand because we need _get_service_metadata_from_registry
+class MPEChannelCommand(MPEServiceCommand):
+
+    # get persistent storage for mpe
+    def _get_persistent_mpe_dir(self):
+        return Path.home().joinpath(".snet", "mpe_client")
+
+    # get persistent storage for the given channel (~/.snet/mpe_client/<mpe_address>/<channel-id>/)
+    def _get_channel_dir(self, channel_id):
+        mpe_address = self.get_mpe_address().lower()
+        return self._get_persistent_mpe_dir().joinpath(mpe_address, str(channel_id))
+
+    def get_channel_dir(self):
+        return self._get_channel_dir(self.args.channel_id)
+
+    def _save_channel_info_dir(self, channel_dir, channel_info):
+        fn = os.path.join(channel_dir, "channel_info.pickle")
+        pickle.dump( channel_info, open( fn, "wb" ) )
+
+    def _read_channel_info(self, channel_id):
+        fn = os.path.join(self._get_channel_dir(channel_id), "channel_info.pickle")
+        return pickle.load( open( fn, "rb" ) )
+
+    # we make sure that MultiPartyEscrow address from metadata is correct
+    def _check_mpe_address_metadata(self, metadata):
+        mpe_address = self.get_mpe_address()
+        if (str(mpe_address).lower() != str(metadata["mpe_address"]).lower()):
+            raise Exception("MultiPartyEscrow contract address from metadata %s do not correspond to current MultiPartyEscrow address %s"%(metadata["mpe_address"], mpe_address))
+
+    def _init_channel_from_metadata(self, channel_dir, metadata, channel_info):
+        self._check_mpe_address_metadata(metadata)
+        if (os.path.exists(channel_dir)):
+            raise Exception("Directory %s already exists"%channel_dir)
+
+        os.makedirs(channel_dir, mode=0o700)
+        try:
+            spec_dir = os.path.join(channel_dir, "service_spec")
+            os.makedirs(spec_dir, mode=0o700)
+            safe_extract_proto_from_ipfs(self._get_ipfs_client(), metadata["model_ipfs_hash"], spec_dir)
+
+            # compile .proto files
+            if (not compile_proto(Path(spec_dir), channel_dir)):
+                raise Exception("Fail to compile %s/*.proto"%spec_dir)
+
+            # save service_metadata.json in channel_dir
+            metadata.save_pretty(os.path.join(channel_dir, "service_metadata.json"))
+
+            # save channel_info (we need sender and signer)
+            self._save_channel_info_dir(channel_dir, channel_info)
+        except:
+            # it is secure to remove channel_dir, because we've created it
+            shutil.rmtree(channel_dir)
+            raise
+
+    def _check_channel_is_mine(self, channel):
+        if (channel["sender"].lower() != self.ident.address.lower() and
+            channel["signer"].lower() != self.ident.address.lower()):
+                raise Exception("Channel %i does not correspond to the current Ethereum identity "%channel_id +
+                                 "(address=%s sender=%s signer=%s)"%(self.ident.address.lower(), channel["sender"].lower(), channel["signer"].lower()))
+
+    def _try_init_channel_from_metadata(self, metadata):
+        channel = self._get_channel_state_from_blockchain(self.args.channel_id)
+        channel_id = self.args.channel_id
+        if (channel["sender"].lower() != self.ident.address.lower() and
+            channel["signer"].lower() != self.ident.address.lower()):
+                raise Exception("Channel %i does not correspond to the current Ethereum identity "%channel_id +
+                                "(address=%s sender=%s signer=%s)"%(self.ident.address.lower(), channel["sender"].lower(), channel["signer"].lower()))
+        group_name = metadata.get_group_by_group_id(channel["groupId"])
+        if (not group_name):
+            group_id_base64 = base64.b64encode(channel["groupId"]).decode('ascii')
+            raise Exception("Channel %i does not correspond to the given metadata.\n"%channel_id +
+                             "We canot find the following group_id in metadata: " + group_id_base64)
+        self._printout("#group_name")
+        self._printout(group_name["group_name"])
+        self._init_channel_from_metadata(self.get_channel_dir(), metadata, channel)
+
+    def init_channel_from_metadata(self):
+        metadata  = load_mpe_service_metadata(self.args.metadata_file)
+        self._try_init_channel_from_metadata(metadata)
+
+    def init_channel_from_registry(self):
+        metadata      = self._get_service_metadata_from_registry()
+        self._try_init_channel_from_metadata(metadata)
+
+    def _open_channel_for_service(self, metadata):
+        group_id    = metadata.get_group_id(self.args.group_name)
+        recipient   = metadata.get_payment_address(self.args.group_name)
+
+        channel_info = {"sender": self.ident.address, "signer": self.ident.address, "recipient": recipient, "groupId" : group_id}
+        params = [channel_info["signer"], channel_info["recipient"], channel_info["groupId"], self.args.amount, self.args.expiration]
+        rez = self.transact_contract_command("MultiPartyEscrow", "openChannel", params)
+
+        if (len(rez[1]) != 1 or rez[1][0]["event"] != "ChannelOpen"):
+            raise Exception("We've expected only one ChannelOpen event after openChannel. Make sure that you use correct MultiPartyEscrow address")
+        return rez[1][0]["args"]["channelId"], channel_info
+
+    def _open_init_channel_from_metadata(self, metadata):
+        # try to initilize channel without actually open it (we check metadata and we compile .proto files)
+        tmp_dir = tempfile.mkdtemp()
+        shutil.rmtree(tmp_dir)
+        self._init_channel_from_metadata(tmp_dir, metadata, {})
+        shutil.rmtree(tmp_dir)
+
+        # open payment channel
+        channel_id, channel_info = self._open_channel_for_service(metadata)
+        self._printout("#channel_id")
+        self._printout(channel_id)
+
+        # initilize new channel
+        self._init_channel_from_metadata(self._get_channel_dir(channel_id), metadata, channel_info)
+
+    def open_init_channel_from_metadata(self):
+        metadata  = load_mpe_service_metadata(self.args.metadata_file)
+        self._open_init_channel_from_metadata(metadata)
+
+    def open_init_channel_from_registry(self):
+        metadata   = self._get_service_metadata_from_registry()
+        self._open_init_channel_from_metadata(metadata)
+
+    def channel_claim_timeout(self):
+        rez = self._get_channel_state_from_blockchain(self.args.channel_id)
+        if (rez["value"] == 0):
+            raise Exception("Channel has 0 value. There is nothing to claim")
+        self.transact_contract_command("MultiPartyEscrow", "channelClaimTimeout", [self.args.channel_id])
+
+    def channel_extend_and_add_funds(self):
+        self.transact_contract_command("MultiPartyEscrow", "channelExtendAndAddFunds", [self.args.channel_id, self.args.expiration, self.args.amount])
+
+    # return list of tuples (channel_id, channel_info)
+    def _get_all_initilized_channels(self):
+        channels = []
+        for channel_dir in self._get_channel_dir(0).parent.glob("*"):
+            if (channel_dir.name.isdigit()):
+                channel_id    = int(channel_dir.name)
+                channel_info  = self._read_channel_info(channel_id)
+                channels.append((channel_id, channel_info))
+        return channels
+
+    def _get_channel_state_from_blockchain(self, channel_id):
+        abi         = get_contract_def("MultiPartyEscrow")
+        channel_abi = abi_get_element_by_name(abi, "channels")
+        channel     = self.call_contract_command("MultiPartyEscrow",  "channels", [channel_id])
+        channel     = abi_decode_struct_to_dict(channel_abi, channel)
+        return channel
+
+    def _print_channels_from_blockchain(self, channels_ids):
+        channels_ids = sorted(channels_ids)
+        if (self.args.only_id):
+            self._printout("#channelId")
+            [self._printout(str(i)) for i in channels_ids]
+            return
+        self._printout("#channelId  nonce  recipient  groupId(base64) value(AGI)  expiration(blocks)")
+        for i in channels_ids:
+            channel = self._get_channel_state_from_blockchain(i)
+            value_agi = cogs2stragi(channel["value"])
+            group_id_base64 = base64.b64encode(channel["groupId"]).decode("ascii")
+            self._printout("%i %i %s %s %s %i"%(i, channel["nonce"], channel["recipient"], group_id_base64,
+                                                   value_agi, channel["expiration"]))
+
+    def _filter_channels_sender_signer(self, channels):
+        good_id = []
+        for channel_id, channel_info in channels:
+            not_sender = channel_info["sender"] != self.ident.address
+            not_signer = channel_info["signer"] != self.ident.address
+            if (self.args.filter_sender and not_sender):
+                continue
+            if (self.args.filter_signer and not_signer):
+                continue
+            if (self.args.filter_my and not_sender and not_signer):
+                continue
+            good_id.append(channel_id)
+        return good_id
+
+    def print_initialized_channels(self):
+        channels = self._get_all_initilized_channels()
+        good_ids = self._filter_channels_sender_signer(channels)
+        self._print_channels_from_blockchain(good_ids)
+
+    def print_initialized_channels_filter_group(self):
+        channels = self._get_all_initilized_channels()
+        metadata = self._get_service_metadata_from_registry()
+        group_id = metadata.get_group_id(self.args.group_name)
+
+        # filter channels for specific group_id
+        channels = [(cid, cinfo) for cid, cinfo in channels if (cinfo["groupId"] == group_id)]
+        good_ids = self._filter_channels_sender_signer(channels)
+        self._print_channels_from_blockchain(good_ids)
+
+    # function for get all filtered chanels from blockchain logs
+    def _get_all_filtered_channels(self, argument_filters, from_block):
+        mpe_address = self.get_mpe_address()
+        abi = get_contract_def("MultiPartyEscrow")["abi"]
+        contract = Contract(self.w3, mpe_address, abi)
+        contract = contract.contract
+        filter = contract.events.ChannelOpen.createFilter(fromBlock=from_block, argument_filters=argument_filters)
+        events = filter.get_all_entries()
+        return [e["args"]["channelId"] for e in events]
+
+    def print_all_channels_filter_sender(self):
+        channels_ids = self._get_all_filtered_channels({"sender":self.ident.address}, self.args.from_block)
+        self._print_channels_from_blockchain(channels_ids)
+
+    def print_all_channels_filter_recipient(self):
+        channels_ids = self._get_all_filtered_channels({"recipient":self.ident.address}, self.args.from_block)
+        self._print_channels_from_blockchain(channels_ids)
+
+    def print_all_channels_filter_group(self):
+        metadata = self._get_service_metadata_from_registry()
+        group_id = metadata.get_group_id(self.args.group_name)
+        channels_ids = self._get_all_filtered_channels({"groupId": group_id}, self.args.from_block)
+        self._print_channels_from_blockchain(channels_ids)
+
+    def print_all_channels_filter_group_sender(self):
+        metadata = self._get_service_metadata_from_registry()
+        group_id = metadata.get_group_id(self.args.group_name)
+        channels_ids = self._get_all_filtered_channels({"groupId": group_id, "sender": self.ident.address}, self.args.from_block)
+        self._print_channels_from_blockchain(channels_ids)
+
+    #Auxilary functions
+    def print_block_number(self):
+         self._printout(self.ident.w3.eth.blockNumber)

--- a/snet_cli/mpe_client_command.py
+++ b/snet_cli/mpe_client_command.py
@@ -146,6 +146,9 @@ class MPEClientCommand(BlockchainCommand):
         self._open_init_channel_from_metadata(metadata)
 
     def channel_claim_timeout(self):
+        rez = self._get_channel_state_from_blockchain(self.args.channel_id)
+        if (rez["value"] == 0):
+            raise Exception("Channel has 0 value. There is nothing to claim")
         self.transact_contract_command("MultiPartyEscrow", "channelClaimTimeout", [self.args.channel_id])
 
     def channel_extend_and_add_funds(self):

--- a/snet_cli/mpe_client_command.py
+++ b/snet_cli/mpe_client_command.py
@@ -121,7 +121,7 @@ class MPEClientCommand(BlockchainCommand):
     def _open_channel_for_service(self, metadata):
         group_id    = metadata.get_group_id(self.args.group_name)
         recipient   = metadata.get_payment_address(self.args.group_name)
-        rez = self.transact_contract_command("MultiPartyEscrow", "openChannel", [recipient, self.args.amount, self.args.expiration, group_id, self.ident.address])
+        rez = self.transact_contract_command("MultiPartyEscrow", "openChannel", [self.ident.address, recipient, group_id, self.args.amount, self.args.expiration])
 
         if (len(rez[1]) != 1 or rez[1][0]["event"] != "ChannelOpen"):
             raise Exception("We've expected only one ChannelOpen event after openChannel. Make sure that you use correct MultiPartyEscrow address")

--- a/snet_cli/mpe_client_command.py
+++ b/snet_cli/mpe_client_command.py
@@ -13,9 +13,7 @@ from snet_cli.utils import get_contract_def, abi_get_element_by_name, abi_decode
 from snet_cli.utils_proto import import_protobuf_from_dir, switch_to_json_payload_econding
 from snet_cli.utils import type_converter
 from snet_cli.mpe_service_metadata import mpe_service_metadata_from_json, load_mpe_service_metadata
-from snet_cli.utils_ipfs import bytesuri_to_hash, get_from_ipfs_and_checkhash
-import tarfile
-import io
+from snet_cli.utils_ipfs import bytesuri_to_hash, get_from_ipfs_and_checkhash, safe_extract_proto_from_ipfs
 import shutil
 import tempfile
 from snet_cli.utils_agi2cogs import cogs2stragi
@@ -84,10 +82,7 @@ class MPEClientCommand(BlockchainCommand):
         try:
             spec_dir = os.path.join(channel_dir, "service_spec")
             os.makedirs(spec_dir, mode=0o700)
-            # take tar of .proto files from ipfs and extract them to channel_dir/service_spec
-            spec_tar = get_from_ipfs_and_checkhash(self._get_ipfs_client(), metadata["model_ipfs_hash"])
-            with tarfile.open(fileobj=io.BytesIO(spec_tar)) as f:
-                f.extractall(spec_dir)
+            safe_extract_proto_from_ipfs(self._get_ipfs_client(), metadata["model_ipfs_hash"], spec_dir)
 
             # compile .proto files
             if (not compile_proto(Path(spec_dir), channel_dir)):

--- a/snet_cli/mpe_client_command.py
+++ b/snet_cli/mpe_client_command.py
@@ -23,40 +23,6 @@ class MPEClientCommand(BlockchainCommand):
 
     # O. MultiPartyEscrow related functions
 
-    def print_account(self):
-        self._printout(self.ident.address)
-
-    # print balance of ETH, AGI, and MPE wallet
-    def print_agi_and_mpe_balances(self):
-        if (self.args.account):
-            account = self.args.account
-        else:
-            account = self.ident.address
-        eth_wei  = self.w3.eth.getBalance(account)
-        agi_cogs = self.call_contract_command("SingularityNetToken", "balanceOf", [account])
-        mpe_cogs = self.call_contract_command("MultiPartyEscrow",    "balances",  [account])
-
-        # we cannot use _pprint here because it doesn't conserve order yet
-        self._printout("    account: %s"%account)
-        self._printout("    ETH: %s"%self.w3.fromWei(eth_wei, 'ether'))
-        self._printout("    AGI: %s"%cogs2stragi(agi_cogs))
-        self._printout("    MPE: %s"%cogs2stragi(mpe_cogs))
-
-    def deposit_to_mpe(self):
-        amount      = self.args.amount
-        mpe_address = self.get_mpe_address()
-
-        already_approved = self.call_contract_command("SingularityNetToken", "allowance", [self.ident.address, mpe_address])
-        if (already_approved < amount):
-            self.transact_contract_command("SingularityNetToken", "approve", [mpe_address, amount])
-        self.transact_contract_command("MultiPartyEscrow", "deposit", [amount])
-
-    def withdraw_from_mpe(self):
-        self.transact_contract_command("MultiPartyEscrow", "withdraw", [self.args.amount])
-
-    def transfer_in_mpe(self):
-        self.transact_contract_command("MultiPartyEscrow", "transfer", [self.args.receiver, self.args.amount])
-
     #TODO: this function is copy paste from mpe_service_command.py
     def _get_service_metadata_from_registry(self):
         params = [type_converter("bytes32")(self.args.org_id), type_converter("bytes32")(self.args.service_id)]

--- a/snet_cli/mpe_client_command.py
+++ b/snet_cli/mpe_client_command.py
@@ -61,10 +61,10 @@ class MPEClientCommand(BlockchainCommand):
 
     #TODO: this function is copy paste from mpe_service_command.py
     def _get_service_metadata_from_registry(self):
-        params = [type_converter("bytes32")(self.args.organization), type_converter("bytes32")(self.args.service)]
-        rez = self.call_contract_command("Registry", "getServiceRegistrationByName", params)
+        params = [type_converter("bytes32")(self.args.org_id), type_converter("bytes32")(self.args.service_id)]
+        rez = self.call_contract_command("Registry", "getServiceRegistrationById", params)
         if (rez[0] == False):
-            raise Exception("Cannot find Service %s in Organization %s"%(self.args.service, self.args.organization))
+            raise Exception("Cannot find Service with id=%s in Organization with id=%s"%(self.args.service_id, self.args.org_id))
         metadata_hash = bytesuri_to_hash(rez[2])
         metadata_json = get_from_ipfs_and_checkhash(self._get_ipfs_client(), metadata_hash)
         metadata      = mpe_service_metadata_from_json(metadata_json)

--- a/snet_cli/mpe_client_command.py
+++ b/snet_cli/mpe_client_command.py
@@ -291,7 +291,7 @@ class MPEClientCommand(BlockchainCommand):
     def print_all_channels_my(self):
         # TODO: check that it is faster to use events to get all channels with the given sender (instead of using channels directly)
         mpe_address = self.get_mpe_address()
-        event_signature   = self.ident.w3.sha3(text="ChannelOpen(uint256,address,address,bytes32,address,uint256,uint256)").hex()
+        event_signature   = self.ident.w3.sha3(text="ChannelOpen(uint256,uint256,address,address,address,bytes32,uint256,uint256)").hex()
         my_address_padded = pad_hex(self.ident.address.lower(), 256)
         logs = self.ident.w3.eth.getLogs({"fromBlock" : self.args.from_block,
                                           "address"   : mpe_address,

--- a/snet_cli/mpe_service_command.py
+++ b/snet_cli/mpe_service_command.py
@@ -65,17 +65,17 @@ class MPEServiceCommand(BlockchainCommand):
     def publish_service_with_metadata(self):
         metadata_uri     = hash_to_bytesuri( self._publish_metadata_in_ipfs(self.args.metadata_file))
         tags             = self._get_converted_tags()
-        params           = [type_converter("bytes32")(self.args.organization), type_converter("bytes32")(self.args.service), metadata_uri, tags]
+        params           = [type_converter("bytes32")(self.args.org_id), type_converter("bytes32")(self.args.service_id), metadata_uri, tags]
         self.transact_contract_command("Registry", "createServiceRegistration", params)
 
     def publish_metadata_in_ipfs_and_update_registration(self):
         metadata_uri     = hash_to_bytesuri( self._publish_metadata_in_ipfs(self.args.metadata_file))
-        params           = [type_converter("bytes32")(self.args.organization), type_converter("bytes32")(self.args.service), metadata_uri]
+        params           = [type_converter("bytes32")(self.args.org_id), type_converter("bytes32")(self.args.service_id), metadata_uri]
         self.transact_contract_command("Registry", "updateServiceRegistration", params)
 
     def _get_params_for_tags_update(self):
         tags             = self._get_converted_tags()
-        params           = [type_converter("bytes32")(self.args.organization), type_converter("bytes32")(self.args.service), tags]
+        params           = [type_converter("bytes32")(self.args.org_id), type_converter("bytes32")(self.args.service_id), tags]
         return params
     
     def update_registration_add_tags(self):
@@ -87,10 +87,10 @@ class MPEServiceCommand(BlockchainCommand):
         self.transact_contract_command("Registry", "removeTagsFromServiceRegistration", params)
         
     def _get_service_registration(self):
-        params = [type_converter("bytes32")(self.args.organization), type_converter("bytes32")(self.args.service)]
-        rez = self.call_contract_command("Registry", "getServiceRegistrationByName", params)
+        params = [type_converter("bytes32")(self.args.org_id), type_converter("bytes32")(self.args.service_id)]
+        rez = self.call_contract_command("Registry", "getServiceRegistrationById", params)
         if (rez[0] == False):
-            raise Exception("Cannot find Service %s in Organization %s"%(self.args.service, self.args.organization))
+            raise Exception("Cannot find Service with id=%s in Organization with id=%s"%(self.args.service_id, self.args.org_id))
         return rez
         
     def print_service_metadata_from_registry(self):
@@ -108,5 +108,5 @@ class MPEServiceCommand(BlockchainCommand):
         self._printout(" ".join(tags))
 
     def delete_service_registration(self):
-        params = [type_converter("bytes32")(self.args.organization), type_converter("bytes32")(self.args.service)]
+        params = [type_converter("bytes32")(self.args.org_id), type_converter("bytes32")(self.args.service_id)]
         self.transact_contract_command("Registry", "deleteServiceRegistration", params)

--- a/snet_cli/mpe_service_command.py
+++ b/snet_cli/mpe_service_command.py
@@ -1,14 +1,14 @@
 from snet_cli.commands    import BlockchainCommand
 import snet_cli.utils_ipfs as utils_ipfs
 from snet_cli.mpe_service_metadata import MPEServiceMetadata, load_mpe_service_metadata, mpe_service_metadata_from_json
-from snet_cli.utils import type_converter
-from snet_cli.utils_ipfs import hash_to_bytesuri, bytesuri_to_hash, get_from_ipfs_and_checkhash
+from snet_cli.utils import type_converter, bytes32_to_str
+from snet_cli.utils_ipfs import hash_to_bytesuri, bytesuri_to_hash, get_from_ipfs_and_checkhash, safe_extract_proto_from_ipfs
 import web3
 
 class MPEServiceCommand(BlockchainCommand):
-        
+
     # I. Low level functions
-    
+
     # publis proto files in ipfs and print hash
     def publish_proto_in_ipfs(self):
         ipfs_hash_base58 = utils_ipfs.publish_proto_in_ipfs(self._get_ipfs_client(), self.args.protodir)
@@ -27,7 +27,7 @@ class MPEServiceCommand(BlockchainCommand):
         self._metadata_add_group(metadata)
         metadata.save_pretty(self.args.metadata_file)
 
-    def metadata_set_fixed_price(self):        
+    def metadata_set_fixed_price(self):
         metadata = load_mpe_service_metadata(self.args.metadata_file)
         metadata.set_fixed_price_in_cogs(self.args.price)
         metadata.save_pretty(self.args.metadata_file)
@@ -54,14 +54,14 @@ class MPEServiceCommand(BlockchainCommand):
     def _publish_metadata_in_ipfs(self, metadata_file):
         metadata = load_mpe_service_metadata(metadata_file)
         return self._get_ipfs_client().add_bytes(metadata.get_json().encode("utf-8"))
-    
+
     # publish metadata in ipfs and print hash
     def publish_metadata_in_ipfs(self):
         self._printout( self._publish_metadata_in_ipfs(self.args.metadata_file) )
-    
+
     def _get_converted_tags(self):
         return [type_converter("bytes32")(tag) for tag in self.args.tags]
-    
+
     def publish_service_with_metadata(self):
         metadata_uri     = hash_to_bytesuri( self._publish_metadata_in_ipfs(self.args.metadata_file))
         tags             = self._get_converted_tags()
@@ -77,7 +77,7 @@ class MPEServiceCommand(BlockchainCommand):
         tags             = self._get_converted_tags()
         params           = [type_converter("bytes32")(self.args.org_id), type_converter("bytes32")(self.args.service_id), tags]
         return params
-    
+
     def update_registration_add_tags(self):
         params = self._get_params_for_tags_update()
         self.transact_contract_command("Registry", "addTagsToServiceRegistration", params)
@@ -85,27 +85,39 @@ class MPEServiceCommand(BlockchainCommand):
     def update_registration_remove_tags(self):
         params = self._get_params_for_tags_update()
         self.transact_contract_command("Registry", "removeTagsFromServiceRegistration", params)
-        
+
     def _get_service_registration(self):
         params = [type_converter("bytes32")(self.args.org_id), type_converter("bytes32")(self.args.service_id)]
         rez = self.call_contract_command("Registry", "getServiceRegistrationById", params)
         if (rez[0] == False):
             raise Exception("Cannot find Service with id=%s in Organization with id=%s"%(self.args.service_id, self.args.org_id))
         return rez
-        
-    def print_service_metadata_from_registry(self):
+
+    def _get_service_metadata_from_registry(self):
         rez           = self._get_service_registration()
         metadata_hash = bytesuri_to_hash(rez[2])
         metadata      = get_from_ipfs_and_checkhash(self._get_ipfs_client(), metadata_hash)
         metadata      = metadata.decode("utf-8")
         metadata      = mpe_service_metadata_from_json(metadata)
+        return metadata
+
+    def print_service_metadata_from_registry(self):
+        metadata      = self._get_service_metadata_from_registry()
         self._printout(metadata.get_json_pretty())
 
     def print_service_tags_from_registry(self):
         rez  = self._get_service_registration()
         tags = rez[3]
-        tags = [tag.rstrip(b"\0").decode('utf-8') for tag in tags]
+        tags = [bytes32_to_str(tag) for tag in tags]
         self._printout(" ".join(tags))
+
+    def extract_service_api_from_metadata(self):
+        metadata = load_mpe_service_metadata(self.args.metadata_file)
+        safe_extract_proto_from_ipfs(self._get_ipfs_client(), metadata["model_ipfs_hash"], self.args.protodir)
+
+    def extract_service_api_from_registry(self):
+        metadata = self._get_service_metadata_from_registry()
+        safe_extract_proto_from_ipfs(self._get_ipfs_client(), metadata["model_ipfs_hash"], self.args.protodir)
 
     def delete_service_registration(self):
         params = [type_converter("bytes32")(self.args.org_id), type_converter("bytes32")(self.args.service_id)]

--- a/snet_cli/mpe_service_command.py
+++ b/snet_cli/mpe_service_command.py
@@ -7,8 +7,6 @@ import web3
 
 class MPEServiceCommand(BlockchainCommand):
 
-    # I. Low level functions
-
     # publis proto files in ipfs and print hash
     def publish_proto_in_ipfs(self):
         ipfs_hash_base58 = utils_ipfs.publish_proto_in_ipfs(self._get_ipfs_client(), self.args.protodir)

--- a/snet_cli/mpe_service_command.py
+++ b/snet_cli/mpe_service_command.py
@@ -25,6 +25,10 @@ class MPEServiceCommand(BlockchainCommand):
         metadata.set_simple_field("service_type",                 self.args.service_type)
         metadata.set_simple_field("payment_expiration_threshold", self.args.payment_expiration_threshold)
         self._metadata_add_group(metadata)
+        for endpoint in self.args.endpoints:
+            metadata.add_endpoint(self.args.group_name, endpoint)
+        if (self.args.fixed_price):
+            metadata.set_fixed_price_in_cogs(self.args.fixed_price)
         metadata.save_pretty(self.args.metadata_file)
 
     def metadata_set_fixed_price(self):

--- a/snet_cli/mpe_service_metadata.py
+++ b/snet_cli/mpe_service_metadata.py
@@ -66,7 +66,7 @@ class MPEServiceMetadata:
                  
     # return new group_id in base64
     def add_group(self, group_name, payment_address):
-        if (self._is_group_present(group_name)):
+        if (self.is_group_name_exists(group_name)):
             raise Exception("the group \"%s\" is already present"%str(group_name))
         group_id_base64 = base64.b64encode(secrets.token_bytes(32))
         self.m["groups"] += [{"group_name"      : group_name , 
@@ -75,19 +75,28 @@ class MPEServiceMetadata:
         return group_id_base64
     
     def add_endpoint(self, group_name, endpoint):
-        if (not self._is_group_present(group_name)):
+        if (not self.is_group_name_exists(group_name)):
             raise Exception("the group %s is not present"%str(group_name))
         if (endpoint in self.get_all_endpoints()):
             raise Exception("the endpoint %s is already present"%str(endpoint))
         self.m["endpoints"] += [{"group_name" : group_name, "endpoint"   : endpoint}]
     
-    # check if group is already present
-    def _is_group_present(self, group_name):
+    # check if group with given name is already exists
+    def is_group_name_exists(self, group_name):
         groups = self.m["groups"]
         for g in groups:
             if (g["group_name"] == group_name):
                 return True
         return False
+
+    # return group with given group_id (return None if doesn't exists)
+    def get_group_by_group_id(self, group_id):
+        group_id_base64 = base64.b64encode(group_id).decode('ascii')
+        groups = self.m["groups"]
+        for g in groups:
+            if (g["group_id"] == group_id_base64):
+                return g
+        return None
 
     def get_json(self):
         return json.dumps(self.m)

--- a/snet_cli/utils.py
+++ b/snet_cli/utils.py
@@ -81,6 +81,10 @@ def type_converter(t):
             return str
 
 
+def bytes32_to_str(b):
+    return b.partition(b"\0")[0].decode("utf-8")
+
+
 def _add_next_paths(path, entry_path, seen_paths, next_paths):
     with open(path) as f:
         for line in f:

--- a/snet_cli/utils.py
+++ b/snet_cli/utils.py
@@ -82,7 +82,7 @@ def type_converter(t):
 
 
 def bytes32_to_str(b):
-    return b.partition(b"\0")[0].decode("utf-8")
+    return b.rstrip(b"\0").decode("utf-8")
 
 
 def _add_next_paths(path, entry_path, seen_paths, next_paths):

--- a/snet_cli/utils_ipfs.py
+++ b/snet_cli/utils_ipfs.py
@@ -3,7 +3,7 @@ import tarfile
 import glob
 import io
 import os
-
+import sys
 
 # make tar from protodir/*proto, and publish this tar in ipfs
 # return base58 encoded ipfs hash
@@ -32,7 +32,7 @@ def publish_proto_in_ipfs(ipfs_client, protodir):
 # We must check the hash becasue we cannot believe that ipfs_client wasn't been compromise
 def get_from_ipfs_and_checkhash(ipfs_client, ipfs_hash_base58):
     data  = ipfs_client.cat(ipfs_hash_base58)
-    print("!!! We must check that hash in IPFS is correct (we cannot be sure that ipfs is not compromized) !!! Please implement it !!!")
+    print("!!! We must check that hash in IPFS is correct (we cannot be sure that ipfs is not compromized) !!! Please implement it !!!", file=sys.stderr)
     return data
 
 # Convert in and from bytes uri format used in Registry contract

--- a/test/README.md
+++ b/test/README.md
@@ -24,8 +24,8 @@ Functional tests are excecuted in the following environment (see
 * local ethereum network (ganache-cli with mnemonics "gauge enact biology destroy normal tunnel
 slight slide wide sauce ladder produce") is running, and snet-cli is
 configured to use it by default
-* There is already one identity in snet-cli. It is "private-key" identity
-called "snet-user", which corresponds to the first ganache identity.
+* There is already one identity in snet-cli. It is "rcp" identity
+called "snet-user", which by default corresponds to the first ganache identity.
 * snet-cli already know correct addreses for SingularityNetToken, Registry and MultiPartyEscrow contracts, so you shoundn't set them manualy
 
 Examples of tests can be found here: [functional_tests](functional_tests). You should add your tests in

--- a/test/functional_tests/script1_twogroups.sh
+++ b/test/functional_tests/script1_twogroups.sh
@@ -59,6 +59,9 @@ snet client transfer 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18 42 -y -q
 snet client withdraw 1 -y -q
 snet client open_init_channel_metadata 42 1 --group_name group1 -y  -q
 snet client channel_claim_timeout 0 -y -q
+# we do not send transaction second time
+snet client channel_claim_timeout 0 -y -q && exit 1 || echo "fail as expected"
+
 snet client channel_extend_add 0 --expiration 10000 --amount 42 -y  -q
 snet client open_init_channel_registry  testo tests 1 1000000  --group_name group2 -y -q
 

--- a/test/functional_tests/script1_twogroups.sh
+++ b/test/functional_tests/script1_twogroups.sh
@@ -1,24 +1,24 @@
 # service side
 
 #should fail (not existed directory)
-snet service metadata_init ./bad_dir/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1 && exit 1 || echo "fail as expected"
+snet service metadata-init ./bad_dir/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1 && exit 1 || echo "fail as expected"
 
 #should fail (directory doesn't contain any *.proto files)
-snet service metadata_init ./ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1 && exit 1 || echo "fail as expected"
+snet service metadata-init ./ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1 && exit 1 || echo "fail as expected"
 
 # happy flow
-snet service metadata_init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1
-snet service metadata_add_group group2 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18
-snet service metadata_add_endpoints  8.8.8.8:2020 9.8.9.8:8080 --group-name group1
-snet service metadata_add_endpoints  8.8.8.8:22   1.2.3.4:8080 --group-name group2
-snet service metadata_set_fixed_price 0.0001
+snet service metadata-init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1
+snet service metadata-add-group group2 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18
+snet service metadata-add-endpoints  8.8.8.8:2020 9.8.9.8:8080 --group-name group1
+snet service metadata-add-endpoints  8.8.8.8:22   1.2.3.4:8080 --group-name group2
+snet service metadata-set-fixed-price 0.0001
 
-# test --endpoints and --fixed-price options in 'snet service metadata_init'
-snet service metadata_init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1 --fixed-price 0.0001 --endpoints 8.8.8.8:2020 9.8.9.8:8080 --metadata-file service_metadata2.json
+# test --endpoints and --fixed-price options in 'snet service metadata-init'
+snet service metadata-init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1 --fixed-price 0.0001 --endpoints 8.8.8.8:2020 9.8.9.8:8080 --metadata-file service_metadata2.json
 grep fixed_price service_metadata2.json
 grep 9.8.9.8:8080 service_metadata2.json
 
-IPFS_HASH=$(snet service publish_in_ipfs)
+IPFS_HASH=$(snet service publish-in-ipfs)
 ipfs cat $IPFS_HASH > service_metadata2.json
 
 # compare service_metadata.json and service_metadata2.json
@@ -26,24 +26,24 @@ cmp <(jq -S . service_metadata.json) <(jq -S . service_metadata2.json)
 
 snet organization create org1 --org-id testo -y -q
 snet service publish testo tests -y -q
-snet service update_add_tags testo tests tag1 tag2 tag3 -y -q
-snet service update_remove_tags testo tests tag2 tag1 -y -q
-snet service print_tags  testo tests
+snet service update-add-tags testo tests tag1 tag2 tag3 -y -q
+snet service update-remove-tags testo tests tag2 tag1 -y -q
+snet service print-tags  testo tests
 
 # it should have only tag3 now
-cmp <(echo "tag3") <(snet service print_tags testo tests)
+cmp <(echo "tag3") <(snet service print-tags testo tests)
 
-snet service print_metadata  testo tests > service_metadata3.json
+snet service print-metadata  testo tests > service_metadata3.json
 
 # compare service_metadata.json and service_metadata3.json
 cmp <(jq -S . service_metadata.json) <(jq -S . service_metadata3.json)
 
 # test get_api_registry and
-snet service get_api_registry testo tests _d1
-snet service get_api_metadata --metadata-file service_metadata3.json _d2
+snet service get-api-registry testo tests _d1
+snet service get-api-metadata --metadata-file service_metadata3.json _d2
 
 # as usual, by default it is metatada_file=service_metadata.json
-snet service get_api_metadata _d3
+snet service get-api-metadata _d3
 
 cmp ./service_spec1/ExampleService.proto _d1/ExampleService.proto
 cmp ./service_spec1/ExampleService.proto _d2/ExampleService.proto
@@ -56,22 +56,22 @@ snet account balance
 snet account deposit 12345 -y -q
 snet account transfer 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18 42 -y -q
 snet account withdraw 1 -y -q
-snet client open_init_channel_metadata 42 1 --group-name group1 -y  -q
-snet client channel_claim_timeout 0 -y -q
+snet channel open-init-metadata 42 1 --group-name group1 -y  -q
+snet channel claim-timeout 0 -y -q
 # we do not send transaction second time
-snet client channel_claim_timeout 0 -y -q && exit 1 || echo "fail as expected"
+snet channel claim-timeout 0 -y -q && exit 1 || echo "fail as expected"
 
-snet client channel_extend_add 0 --expiration 10000 --amount 42 -y  -q
-snet client open_init_channel_registry  testo tests 1 1000000  --group-name group2 -y -q
+snet channel extend-add 0 --expiration 10000 --amount 42 -y  -q
+snet channel open-init  testo tests 1 1000000  --group-name group2 -y -q
 
 # test print_initialized_channels and print_all_channels. We should have channels openned for specific identity
-snet client print_initialized_channels | grep 0x42A605c07EdE0E1f648aB054775D6D4E38496144
-snet client print_all_channels |grep 0x42A605c07EdE0E1f648aB054775D6D4E38496144
+snet channel print-initialized | grep 0x42A605c07EdE0E1f648aB054775D6D4E38496144
+snet channel print-all-filter-sender |grep 0x42A605c07EdE0E1f648aB054775D6D4E38496144
 
 rm -rf ~/.snet/mpe_client/
-snet client init_channel_metadata 0
-snet client init_channel_registry testo tests 1
-snet client print_initialized_channels
-snet client print_all_channels
+snet channel init-metadata 0
+snet channel init testo tests 1
+snet channel print-initialized
+snet channel print-all-filter-sender
 snet service delete testo tests -y -q
 snet organization list-services testo

--- a/test/functional_tests/script1_twogroups.sh
+++ b/test/functional_tests/script1_twogroups.sh
@@ -61,8 +61,11 @@ snet client open_init_channel_metadata 42 1 --group_name group1 -y  -q
 snet client channel_claim_timeout 0 -y -q
 snet client channel_extend_add 0 --expiration 10000 --amount 42 -y  -q
 snet client open_init_channel_registry  testo tests 1 1000000  --group_name group2 -y -q
-snet client print_initialized_channels
-snet client print_all_channels
+
+# test print_initialized_channels and print_all_channels. We should have channels openned for specific identity
+snet client print_initialized_channels | grep 0x42A605c07EdE0E1f648aB054775D6D4E38496144
+snet client print_all_channels |grep 0x42A605c07EdE0E1f648aB054775D6D4E38496144
+
 rm -rf ~/.snet/mpe_client/
 snet client init_channel_metadata 0
 snet client init_channel_registry testo tests 1 

--- a/test/functional_tests/script1_twogroups.sh
+++ b/test/functional_tests/script1_twogroups.sh
@@ -1,23 +1,22 @@
 # service side
 
 #should fail (not existed directory)
-snet service metadata_init ./bad_dir/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service_type jsonrpc --group_name group1 && exit 1 || echo "fail as expected"
+snet service metadata_init ./bad_dir/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1 && exit 1 || echo "fail as expected"
 
 #should fail (directory doesn't contain any *.proto files)
-snet service metadata_init ./ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service_type jsonrpc --group_name group1 && exit 1 || echo "fail as expected"
+snet service metadata_init ./ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1 && exit 1 || echo "fail as expected"
 
 # happy flow
-snet service metadata_init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service_type jsonrpc --group_name group1
+snet service metadata_init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1
 snet service metadata_add_group group2 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18
-snet service metadata_add_endpoints  8.8.8.8:2020 9.8.9.8:8080 --group_name group1
-snet service metadata_add_endpoints  8.8.8.8:22   1.2.3.4:8080 --group_name group2
+snet service metadata_add_endpoints  8.8.8.8:2020 9.8.9.8:8080 --group-name group1
+snet service metadata_add_endpoints  8.8.8.8:22   1.2.3.4:8080 --group-name group2
 snet service metadata_set_fixed_price 0.0001
 
-# test --endpoints and --fixed_price options in 'snet service metadata_init'
-snet service metadata_init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service_type jsonrpc --group_name group1 --fixed_price 0.0001 --endpoints 8.8.8.8:2020 9.8.9.8:8080 --metadata_file service_metadata2.json
+# test --endpoints and --fixed-price options in 'snet service metadata_init'
+snet service metadata_init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1 --fixed-price 0.0001 --endpoints 8.8.8.8:2020 9.8.9.8:8080 --metadata-file service_metadata2.json
 grep fixed_price service_metadata2.json
 grep 9.8.9.8:8080 service_metadata2.json
-
 
 IPFS_HASH=$(snet service publish_in_ipfs)
 ipfs cat $IPFS_HASH > service_metadata2.json
@@ -41,7 +40,7 @@ cmp <(jq -S . service_metadata.json) <(jq -S . service_metadata3.json)
 
 # test get_api_registry and
 snet service get_api_registry testo tests _d1
-snet service get_api_metadata --metadata_file service_metadata3.json _d2
+snet service get_api_metadata --metadata-file service_metadata3.json _d2
 
 # as usual, by default it is metatada_file=service_metadata.json
 snet service get_api_metadata _d3
@@ -57,13 +56,13 @@ snet client balance
 snet client deposit 12345 -y -q
 snet client transfer 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18 42 -y -q
 snet client withdraw 1 -y -q
-snet client open_init_channel_metadata 42 1 --group_name group1 -y  -q
+snet client open_init_channel_metadata 42 1 --group-name group1 -y  -q
 snet client channel_claim_timeout 0 -y -q
 # we do not send transaction second time
 snet client channel_claim_timeout 0 -y -q && exit 1 || echo "fail as expected"
 
 snet client channel_extend_add 0 --expiration 10000 --amount 42 -y  -q
-snet client open_init_channel_registry  testo tests 1 1000000  --group_name group2 -y -q
+snet client open_init_channel_registry  testo tests 1 1000000  --group-name group2 -y -q
 
 # test print_initialized_channels and print_all_channels. We should have channels openned for specific identity
 snet client print_initialized_channels | grep 0x42A605c07EdE0E1f648aB054775D6D4E38496144

--- a/test/functional_tests/script1_twogroups.sh
+++ b/test/functional_tests/script1_twogroups.sh
@@ -52,10 +52,10 @@ cmp ./service_spec1/ExampleService.proto _d3/ExampleService.proto
 rm -r _d1 _d2 _d3
 
 # client side
-snet client balance 
-snet client deposit 12345 -y -q
-snet client transfer 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18 42 -y -q
-snet client withdraw 1 -y -q
+snet account balance
+snet account deposit 12345 -y -q
+snet account transfer 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18 42 -y -q
+snet account withdraw 1 -y -q
 snet client open_init_channel_metadata 42 1 --group-name group1 -y  -q
 snet client channel_claim_timeout 0 -y -q
 # we do not send transaction second time
@@ -70,7 +70,7 @@ snet client print_all_channels |grep 0x42A605c07EdE0E1f648aB054775D6D4E38496144
 
 rm -rf ~/.snet/mpe_client/
 snet client init_channel_metadata 0
-snet client init_channel_registry testo tests 1 
+snet client init_channel_registry testo tests 1
 snet client print_initialized_channels
 snet client print_all_channels
 snet service delete testo tests -y -q

--- a/test/functional_tests/script1_twogroups.sh
+++ b/test/functional_tests/script1_twogroups.sh
@@ -28,10 +28,23 @@ snet service print_tags  testo tests
 # it should have only tag3 now
 cmp <(echo "tag3") <(snet service print_tags testo tests)
 
-snet service print_metadata  testo tests |grep -v "We must check that hash in IPFS is correct" > service_metadata3.json
+snet service print_metadata  testo tests > service_metadata3.json
 
 # compare service_metadata.json and service_metadata3.json
 cmp <(jq -S . service_metadata.json) <(jq -S . service_metadata3.json)
+
+# test get_api_registry and
+snet service get_api_registry testo tests _d1
+snet service get_api_metadata --metadata_file service_metadata3.json _d2
+
+# as usual, by default it is metatada_file=service_metadata.json
+snet service get_api_metadata _d3
+
+cmp ./service_spec1/ExampleService.proto _d1/ExampleService.proto
+cmp ./service_spec1/ExampleService.proto _d2/ExampleService.proto
+cmp ./service_spec1/ExampleService.proto _d3/ExampleService.proto
+
+rm -r _d1 _d2 _d3
 
 # client side
 snet client balance 

--- a/test/functional_tests/script1_twogroups.sh
+++ b/test/functional_tests/script1_twogroups.sh
@@ -68,7 +68,46 @@ snet channel open-init  testo tests 1 1000000  --group-name group2 -y -q
 snet channel print-initialized | grep 0x42A605c07EdE0E1f648aB054775D6D4E38496144
 snet channel print-all-filter-sender |grep 0x42A605c07EdE0E1f648aB054775D6D4E38496144
 
+# we have two initilized channels one for group1 and anther for group1 (recipient=0x42A605c07EdE0E1f648aB054775D6D4E38496144)
+
+snet service metadata-init ./service_spec1/ ExampleService 0x52653A9091b5d5021bed06c5118D24b23620c529  --fixed-price 0.0001 --endpoints 8.8.8.8:2020 --metadata-file service_metadata2.json
+snet service publish testo tests2 -y -q --metadata-file service_metadata2.json
+
+snet channel open-init testo tests2 42 1 -y  -q --signer 0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB
+
+snet channel print-initialized-filter-group testo tests2
+snet channel print-initialized-filter-group testo tests2 |grep 0x52653A9091b5d5021bed06c5118D24b23620c529
+snet channel print-initialized-filter-group testo tests2 |grep 0x42A605c07EdE0E1f648aB054775D6D4E38496144 && exit 1 || echo "fail as expected"
+
+snet channel print-initialized
+snet channel print-initialized | grep 0x52653A9091b5d5021bed06c5118D24b23620c529
+snet channel print-initialized | grep 0x42A605c07EdE0E1f648aB054775D6D4E38496144
+
+snet channel print-initialized --only-id
+snet channel print-initialized --only-id | grep 0x42A605c07EdE0E1f648aB054775D6D4E38496144 && exit 1 || echo "fail as expected"
+
+snet channel print-initialized --filter-signer | grep 0x52653A9091b5d5021bed06c5118D24b23620c529 && exit 1 || echo "fail as expected"
+snet channel print-initialized --filter-signer --wallet-index 1 | grep 0x52653A9091b5d5021bed06c5118D24b23620c529
+
+snet channel  print-initialized-filter-group testo tests2
+snet channel  print-initialized-filter-group testo tests2 |grep 0x52653A9091b5d5021bed06c5118D24b23620c529
+
 rm -rf ~/.snet/mpe_client/
+
+snet channel print-all-filter-sender
+snet channel print-all-filter-sender | grep 0x52653A9091b5d5021bed06c5118D24b23620c529
+
+snet channel print-all-filter-recipient | grep 0x52653A9091b5d5021bed06c5118D24b23620c529 && exit 1 || echo "fail as expected"
+snet channel print-all-filter-recipient --wallet-index 9 |grep 0x52653A9091b5d5021bed06c5118D24b23620c529
+
+snet channel print-all-filter-group testo tests2 | grep 0x52653A9091b5d5021bed06c5118D24b23620c529
+snet channel print-all-filter-group testo tests2 | grep 0x42A605c07EdE0E1f648aB054775D6D4E38496144 && exit 1 || echo "fail as expected"
+
+snet channel print-all-filter-group testo tests --group-name group2 |grep 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18
+
+snet channel print-all-filter-group-sender testo tests2 | grep 0x52653A9091b5d5021bed06c5118D24b23620c529
+snet channel print-all-filter-group-sender testo tests2 | grep 0x42A605c07EdE0E1f648aB054775D6D4E38496144 && exit 1 || echo "fail as expected"
+
 snet channel init-metadata 0
 snet channel init testo tests 1
 snet channel print-initialized

--- a/test/functional_tests/script1_twogroups.sh
+++ b/test/functional_tests/script1_twogroups.sh
@@ -1,4 +1,3 @@
-
 # service side
 
 #should fail (not existed directory)
@@ -13,6 +12,13 @@ snet service metadata_add_group group2 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a1
 snet service metadata_add_endpoints  8.8.8.8:2020 9.8.9.8:8080 --group_name group1
 snet service metadata_add_endpoints  8.8.8.8:22   1.2.3.4:8080 --group_name group2
 snet service metadata_set_fixed_price 0.0001
+
+# test --endpoints and --fixed_price options in 'snet service metadata_init'
+snet service metadata_init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service_type jsonrpc --group_name group1 --fixed_price 0.0001 --endpoints 8.8.8.8:2020 9.8.9.8:8080 --metadata_file service_metadata2.json
+grep fixed_price service_metadata2.json
+grep 9.8.9.8:8080 service_metadata2.json
+
+
 IPFS_HASH=$(snet service publish_in_ipfs)
 ipfs cat $IPFS_HASH > service_metadata2.json
 

--- a/test/functional_tests/script1_twogroups.sh
+++ b/test/functional_tests/script1_twogroups.sh
@@ -19,7 +19,7 @@ ipfs cat $IPFS_HASH > service_metadata2.json
 # compare service_metadata.json and service_metadata2.json
 cmp <(jq -S . service_metadata.json) <(jq -S . service_metadata2.json)
 
-snet organization create testo -y -q
+snet organization create org1 --org-id testo -y -q
 snet service publish testo tests -y -q
 snet service update_add_tags testo tests tag1 tag2 tag3 -y -q
 snet service update_remove_tags testo tests tag2 tag1 -y -q

--- a/test/functional_tests/script2_deposit_transfer.sh
+++ b/test/functional_tests/script2_deposit_transfer.sh
@@ -1,24 +1,24 @@
 # test deposit and transfer functions in snet client
 
 # initial balance should be 0
-MPE_BALANCE=$(snet client balance|grep MPE)
+MPE_BALANCE=$(snet account balance|grep MPE)
 test ${MPE_BALANCE##*:} = "0"
 
-snet client deposit 12345.678 -y -q
+snet account deposit 12345.678 -y -q
 
-MPE_BALANCE=$(snet client balance|grep MPE)
+MPE_BALANCE=$(snet account balance|grep MPE)
 test ${MPE_BALANCE##*:} = "12345.678"
 
-snet client transfer 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18 42.314 -y -q
+snet account transfer 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18 42.314 -y -q
 
-MPE_BALANCE=$(snet client balance --account 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18|grep MPE)
+MPE_BALANCE=$(snet account balance --account 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18|grep MPE)
 test ${MPE_BALANCE##*:} = "42.314"
 
 
-MPE_BALANCE=$(snet client balance|grep MPE)
+MPE_BALANCE=$(snet account balance|grep MPE)
 test ${MPE_BALANCE##*:} = "12303.364"
 
 
-snet client withdraw 1.42 -y -q
-MPE_BALANCE=$(snet client balance|grep MPE)
+snet account withdraw 1.42 -y -q
+MPE_BALANCE=$(snet account balance|grep MPE)
 test ${MPE_BALANCE##*:} = "12301.944"

--- a/test/functional_tests/script3_without_addresses.sh
+++ b/test/functional_tests/script3_without_addresses.sh
@@ -13,7 +13,7 @@ snet unset current_multipartyescrow_at || echo "could fail if hasn't been set (i
 # now snet-cli will work only if we pass contract addresses as commandline arguments
 
 # this should fail without addresses
-snet client balance && exit 1 || echo "fail as expected"
+snet account balance && exit 1 || echo "fail as expected"
 snet organization create testo --org-id testo -y -q  && exit 1 || echo "fail as expected"
 
 
@@ -43,10 +43,10 @@ snet service print_metadata  testo tests --registry-at 0x4e74fefa82e83e0964f0d9f
 cmp <(jq -S . service_metadata.json) <(jq -S . service_metadata3.json)
 
 # client side
-snet client balance --snt 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
-snet client deposit 12345 -y -q --snt 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
-snet client transfer 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18 42 -y -q --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
-snet client withdraw 1 -y -q --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet account balance --snt 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet account deposit 12345 -y -q --snt 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet account transfer 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18 42 -y -q --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet account withdraw 1 -y -q --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet client open_init_channel_metadata 42 1 --group-name group1 -y  -q --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet client channel_claim_timeout 0 -y -q  --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet client channel_extend_add 0 --expiration 10000 --amount 42 -y  -q  --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e

--- a/test/functional_tests/script3_without_addresses.sh
+++ b/test/functional_tests/script3_without_addresses.sh
@@ -14,7 +14,7 @@ snet unset current_multipartyescrow_at || echo "could fail if hasn't been set (i
 
 # this should fail without addresses
 snet client balance && exit 1 || echo "fail as expected"
-snet organization create testo -y -q  && exit 1 || echo "fail as expected"
+snet organization create testo --org-id testo -y -q  && exit 1 || echo "fail as expected"
 
 
 snet service metadata_init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service_type jsonrpc --group_name group1 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e

--- a/test/functional_tests/script3_without_addresses.sh
+++ b/test/functional_tests/script3_without_addresses.sh
@@ -17,12 +17,12 @@ snet account balance && exit 1 || echo "fail as expected"
 snet organization create testo --org-id testo -y -q  && exit 1 || echo "fail as expected"
 
 
-snet service metadata_init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
-snet service metadata_add_group group2 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18
-snet service metadata_add_endpoints  8.8.8.8:2020 9.8.9.8:8080 --group-name group1
-snet service metadata_add_endpoints  8.8.8.8:22   1.2.3.4:8080 --group-name group2
-snet service metadata_set_fixed_price 0.0001
-IPFS_HASH=$(snet service publish_in_ipfs)
+snet service metadata-init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet service metadata-add-group group2 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18
+snet service metadata-add-endpoints  8.8.8.8:2020 9.8.9.8:8080 --group-name group1
+snet service metadata-add-endpoints  8.8.8.8:22   1.2.3.4:8080 --group-name group2
+snet service metadata-set-fixed-price 0.0001
+IPFS_HASH=$(snet service publish-in-ipfs)
 ipfs cat $IPFS_HASH > service_metadata2.json
 
 # compare service_metadata.json and service_metadata2.json
@@ -30,14 +30,14 @@ cmp <(jq -S . service_metadata.json) <(jq -S . service_metadata2.json)
 
 snet organization create testo --org-id testo -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet service publish testo tests -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
-snet service update_add_tags testo tests tag1 tag2 tag3 -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
-snet service update_remove_tags testo tests tag2 tag1 -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
-snet service print_tags  testo tests --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
+snet service update-add-tags testo tests tag1 tag2 tag3 -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
+snet service update-remove-tags testo tests tag2 tag1 -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
+snet service print-tags  testo tests --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet organization list --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 # it should have only tag3 now
-cmp <(echo "tag3") <(snet service print_tags testo tests --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2)
+cmp <(echo "tag3") <(snet service print-tags testo tests --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2)
 
-snet service print_metadata  testo tests --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2 |grep -v "We must check that hash in IPFS is correct" > service_metadata3.json
+snet service print-metadata  testo tests --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2 |grep -v "We must check that hash in IPFS is correct" > service_metadata3.json
 
 # compare service_metadata.json and service_metadata3.json
 cmp <(jq -S . service_metadata.json) <(jq -S . service_metadata3.json)
@@ -47,16 +47,16 @@ snet account balance --snt 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c
 snet account deposit 12345 -y -q --snt 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet account transfer 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18 42 -y -q --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet account withdraw 1 -y -q --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
-snet client open_init_channel_metadata 42 1 --group-name group1 -y  -q --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
-snet client channel_claim_timeout 0 -y -q  --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
-snet client channel_extend_add 0 --expiration 10000 --amount 42 -y  -q  --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
-snet client open_init_channel_registry  testo tests 1 1000000  --group-name group2 -y -q  --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e --registry 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
-snet client print_initialized_channels --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
-snet client print_all_channels --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet channel open-init-metadata 42 1 --group-name group1 -y  -q --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet channel claim-timeout 0 -y -q  --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet channel extend-add 0 --expiration 10000 --amount 42 -y  -q  --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet channel open-init  testo tests 1 1000000  --group-name group2 -y -q  --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e --registry 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
+snet channel print-initialized --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet channel print-all-filter-sender --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 rm -rf ~/.snet/mpe_client/
-snet client init_channel_metadata 0 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
-snet client init_channel_registry testo tests 1  --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e --registry 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
-snet client print_initialized_channels --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
-snet client print_all_channels --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet channel init-metadata 0 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet channel init testo tests 1  --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e --registry 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
+snet channel print-initialized --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet channel print-all-filter-sender --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet service delete testo tests -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet organization list-services testo --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2

--- a/test/functional_tests/script3_without_addresses.sh
+++ b/test/functional_tests/script3_without_addresses.sh
@@ -28,7 +28,7 @@ ipfs cat $IPFS_HASH > service_metadata2.json
 # compare service_metadata.json and service_metadata2.json
 cmp <(jq -S . service_metadata.json) <(jq -S . service_metadata2.json)
 
-snet organization create testo -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
+snet organization create testo --org-id testo -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet service publish testo tests -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet service update_add_tags testo tests tag1 tag2 tag3 -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet service update_remove_tags testo tests tag2 tag1 -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2

--- a/test/functional_tests/script3_without_addresses.sh
+++ b/test/functional_tests/script3_without_addresses.sh
@@ -17,10 +17,10 @@ snet client balance && exit 1 || echo "fail as expected"
 snet organization create testo --org-id testo -y -q  && exit 1 || echo "fail as expected"
 
 
-snet service metadata_init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service_type jsonrpc --group_name group1 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet service metadata_init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet service metadata_add_group group2 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18
-snet service metadata_add_endpoints  8.8.8.8:2020 9.8.9.8:8080 --group_name group1
-snet service metadata_add_endpoints  8.8.8.8:22   1.2.3.4:8080 --group_name group2
+snet service metadata_add_endpoints  8.8.8.8:2020 9.8.9.8:8080 --group-name group1
+snet service metadata_add_endpoints  8.8.8.8:22   1.2.3.4:8080 --group-name group2
 snet service metadata_set_fixed_price 0.0001
 IPFS_HASH=$(snet service publish_in_ipfs)
 ipfs cat $IPFS_HASH > service_metadata2.json
@@ -47,10 +47,10 @@ snet client balance --snt 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c7
 snet client deposit 12345 -y -q --snt 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet client transfer 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18 42 -y -q --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet client withdraw 1 -y -q --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
-snet client open_init_channel_metadata 42 1 --group_name group1 -y  -q --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet client open_init_channel_metadata 42 1 --group-name group1 -y  -q --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet client channel_claim_timeout 0 -y -q  --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet client channel_extend_add 0 --expiration 10000 --amount 42 -y  -q  --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
-snet client open_init_channel_registry  testo tests 1 1000000  --group_name group2 -y -q  --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e --registry 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
+snet client open_init_channel_registry  testo tests 1 1000000  --group-name group2 -y -q  --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e --registry 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet client print_initialized_channels --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet client print_all_channels --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 rm -rf ~/.snet/mpe_client/

--- a/test/functional_tests/script4_only_with_networks.sh
+++ b/test/functional_tests/script4_only_with_networks.sh
@@ -15,7 +15,7 @@ snet unset current_registry_at            || echo "could fail if hasn't been set
 snet unset current_multipartyescrow_at    || echo "could fail if hasn't been set (it is ok)"
 
 # this should fail without addresses
-snet client balance && exit 1 || echo "fail as expected"
+snet account balance && exit 1 || echo "fail as expected"
 snet organization create testo --org-id testo -y -q  && exit 1 || echo "fail as expected"
 
 
@@ -26,25 +26,25 @@ echo '{"829257324":{"events":{},"links":{},"address":"0x6e5f20669177f5bdf3703ec5
 
 
 # this should work
-snet client balance 
+snet account balance
 snet organization create testo --org-id testo -y -q
 snet organization delete testo -y -q
 
 # this should fail (addresses are INVALID)
 snet organization create testo --org-id testo -y -q --registry-at 0x1e74fefa82e83e0964f0d9f53c68e03f7298a8b2 && exit 1 || echo "fail as expected"
-snet client balance --snt 0x1e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e && exit 1 || echo "fail as expected"
+snet account balance --snt 0x1e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e && exit 1 || echo "fail as expected"
 
 # set INVALID addresses
 snet set current_singularitynettoken_at 0x1e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14
 snet set current_registry_at            0x1e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet set current_multipartyescrow_at    0x1c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 
-# this should fail because INVALID address 
-snet client balance && exit 1 || echo "fail as expected"
+# this should fail because INVALID address
+snet account balance && exit 1 || echo "fail as expected"
 snet organization create testo --org-id testo -y -q  && exit 1 || echo "fail as expected"
 
 # this should work because command line has more priority
-snet client balance --snt 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet account balance --snt 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet organization create testo --org-id testo -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet organization delete testo                -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 
@@ -55,7 +55,7 @@ echo '{"829257324":{"events":{},"links":{},"address":"0x1e74fefa82e83e0964f0d9f5
 echo '{"829257324":{"events":{},"links":{},"address":"0x1e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14","transactionHash":""}}' > ../../snet_cli/resources/contracts/networks/SingularityNetToken.json
 
 # this should fail (because addresses in networks are invalid )
-snet client balance && exit 1 || echo "fail as expected"
+snet account balance && exit 1 || echo "fail as expected"
 snet organization create testo --org-id testo -y -q  && exit 1 || echo "fail as expected"
 
 # set VALID session
@@ -64,7 +64,7 @@ snet set current_registry_at            0x4e74fefa82e83e0964f0d9f53c68e03f7298a8
 snet set current_multipartyescrow_at    0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 
 # this should work
-snet client balance 
+snet account balance
 snet organization create testo --org-id testo -y -q
 snet organization delete testo -y -q
 
@@ -74,10 +74,10 @@ snet set current_registry_at            0x1e74fefa82e83e0964f0d9f53c68e03f7298a8
 snet set current_multipartyescrow_at    0x1c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 
 # this should fail (because addresses in networks are invalid )
-snet client balance && exit 1 || echo "fail as expected"
+snet account balance && exit 1 || echo "fail as expected"
 snet organization create testo --org-id testo -y -q  && exit 1 || echo "fail as expected"
 
 # this should work because command line has more priority
-snet client balance --snt 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet account balance --snt 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet organization create testo --org-id testo -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet organization delete testo                -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2

--- a/test/functional_tests/script4_only_with_networks.sh
+++ b/test/functional_tests/script4_only_with_networks.sh
@@ -16,7 +16,7 @@ snet unset current_multipartyescrow_at    || echo "could fail if hasn't been set
 
 # this should fail without addresses
 snet client balance && exit 1 || echo "fail as expected"
-snet organization create testo -y -q  && exit 1 || echo "fail as expected"
+snet organization create testo --org-id testo -y -q  && exit 1 || echo "fail as expected"
 
 
 # set networks
@@ -31,7 +31,7 @@ snet organization create testo --org-id testo -y -q
 snet organization delete testo -y -q
 
 # this should fail (addresses are INVALID)
-snet organization create testo -y -q --registry-at 0x1e74fefa82e83e0964f0d9f53c68e03f7298a8b2 && exit 1 || echo "fail as expected"
+snet organization create testo --org-id testo -y -q --registry-at 0x1e74fefa82e83e0964f0d9f53c68e03f7298a8b2 && exit 1 || echo "fail as expected"
 snet client balance --snt 0x1e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e && exit 1 || echo "fail as expected"
 
 # set INVALID addresses
@@ -41,7 +41,7 @@ snet set current_multipartyescrow_at    0x1c7a4290f6f8ff64c69eeffdfafc8644a4ec3a
 
 # this should fail because INVALID address 
 snet client balance && exit 1 || echo "fail as expected"
-snet organization create testo -y -q  && exit 1 || echo "fail as expected"
+snet organization create testo --org-id testo -y -q  && exit 1 || echo "fail as expected"
 
 # this should work because command line has more priority
 snet client balance --snt 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
@@ -56,7 +56,7 @@ echo '{"829257324":{"events":{},"links":{},"address":"0x1e5f20669177f5bdf3703ec5
 
 # this should fail (because addresses in networks are invalid )
 snet client balance && exit 1 || echo "fail as expected"
-snet organization create testo -y -q  && exit 1 || echo "fail as expected"
+snet organization create testo --org-id testo -y -q  && exit 1 || echo "fail as expected"
 
 # set VALID session
 snet set current_singularitynettoken_at 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14
@@ -75,7 +75,7 @@ snet set current_multipartyescrow_at    0x1c7a4290f6f8ff64c69eeffdfafc8644a4ec3a
 
 # this should fail (because addresses in networks are invalid )
 snet client balance && exit 1 || echo "fail as expected"
-snet organization create testo -y -q  && exit 1 || echo "fail as expected"
+snet organization create testo --org-id testo -y -q  && exit 1 || echo "fail as expected"
 
 # this should work because command line has more priority
 snet client balance --snt 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e

--- a/test/functional_tests/script4_only_with_networks.sh
+++ b/test/functional_tests/script4_only_with_networks.sh
@@ -27,7 +27,7 @@ echo '{"829257324":{"events":{},"links":{},"address":"0x6e5f20669177f5bdf3703ec5
 
 # this should work
 snet client balance 
-snet organization create testo -y -q
+snet organization create testo --org-id testo -y -q
 snet organization delete testo -y -q
 
 # this should fail (addresses are INVALID)
@@ -45,8 +45,8 @@ snet organization create testo -y -q  && exit 1 || echo "fail as expected"
 
 # this should work because command line has more priority
 snet client balance --snt 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
-snet organization create testo -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
-snet organization delete testo -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
+snet organization create testo --org-id testo -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
+snet organization delete testo                -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 
 
 # set INVALID networks
@@ -65,7 +65,7 @@ snet set current_multipartyescrow_at    0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a
 
 # this should work
 snet client balance 
-snet organization create testo -y -q
+snet organization create testo --org-id testo -y -q
 snet organization delete testo -y -q
 
 # set INVALID addresses
@@ -79,5 +79,5 @@ snet organization create testo -y -q  && exit 1 || echo "fail as expected"
 
 # this should work because command line has more priority
 snet client balance --snt 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
-snet organization create testo -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
-snet organization delete testo -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
+snet organization create testo --org-id testo -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
+snet organization delete testo                -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2

--- a/test/functional_tests/script5_identity1_rpc_mnemonic.sh
+++ b/test/functional_tests/script5_identity1_rpc_mnemonic.sh
@@ -13,6 +13,8 @@ assert_mpe_balance () {
 # this should fail because snet-user should be in use now
 snet identity delete snet-user && exit 1 || echo "fail as expected"
 
+snet identity create key0 key --private-key 0xc71478a6d0fe44e763649de0a0deb5a080b788eefbbcf9c6f7aef0dd5dbd67e0 --network local
+
 snet identity create rpc0 rpc --network local
 snet identity rpc0
 
@@ -56,6 +58,11 @@ snet identity rpc0
 # A0 -> M1 0.1
 snet account transfer $M1 0.1 -y
 assert_mpe_balance $M1 0.1
+
+# A0 -> M1 0.2
+snet identity key0
+snet account transfer $M1 0.1 -y
+assert_mpe_balance $M1 0.2
 
 snet identity snet-user
 snet identity delete rpc0

--- a/test/functional_tests/script5_identity1_rpc_mnemonic.sh
+++ b/test/functional_tests/script5_identity1_rpc_mnemonic.sh
@@ -1,11 +1,11 @@
-# test itentities managment. 
+# test itentities managment.
 
 # This is first and second ganache identity
 A0=0x592E3C0f3B038A0D673F19a18a773F993d4b2610
 A1=0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB
 
 assert_mpe_balance () {
-   MPE_BALANCE=$(snet client balance --account $1 |grep MPE)
+   MPE_BALANCE=$(snet account balance --account $1 |grep MPE)
    test ${MPE_BALANCE##*:} = $2
 }
 
@@ -18,43 +18,43 @@ snet identity rpc0
 
 # switch to main net (rpc0 is bind to the local network!)
 snet network mainnet
-snet client balance && exit 1 || echo "fail as expected"
+snet account balance && exit 1 || echo "fail as expected"
 snet network local
 
 
-snet client deposit 100 -y
+snet account deposit 100 -y
 assert_mpe_balance $A0 100
 
 # A0 -> A1  42
-snet client transfer $A1 42 -y
+snet account transfer $A1 42 -y
 assert_mpe_balance $A1 42
 
 snet identity create rpc1 rpc --network local --wallet-index 1
 snet identity rpc1
 
-# A1 -> A0  1 
-snet client transfer $A0 1 -y
+# A1 -> A0  1
+snet account transfer $A0 1 -y
 assert_mpe_balance $A1 41
 
 # A0 -> A1 2
-snet client transfer $A1 2 --wallet-index 0 -y
+snet account transfer $A1 2 --wallet-index 0 -y
 assert_mpe_balance $A1 43
 
 snet identity create mne0 mnemonic --network local --mnemonic "a b c d"
 snet identity mne0
-M0=`snet client account`
-M1=`snet client account --wallet-index 1`
+M0=`snet account print`
+M1=`snet account print --wallet-index 1`
 
 snet identity create mne1 mnemonic --wallet-index 1 --network local --mnemonic "a b c d"
 snet identity mne1
-M11=`snet client account`
+M11=`snet account print`
 
 test $M1 = $M11
 
 snet identity rpc0
 
 # A0 -> M1 0.1
-snet client transfer $M1 0.1 -y
+snet account transfer $M1 0.1 -y
 assert_mpe_balance $M1 0.1
 
 snet identity snet-user

--- a/test/functional_tests/script6_organization.sh
+++ b/test/functional_tests/script6_organization.sh
@@ -19,7 +19,7 @@ snet organization add-members test2 0x5c1011aB3C7f46EC5E78073D61DF6d002983F04a,0
 snet organization add-members test2 0x5c1011aB3C7f46EC5E78073D61DF6d002983F04a,0x42A605c07EdE0E1f648aB054775D6D4E38496144 -y | grep "No member was added"
 snet organization add-members test2 0x5c1011aB3C7f46EC5E78073D61DF6d002983F04a,0x42A605c07EdE0E1f648aB054775D6D4E38496144,0xc990EEAad8c943E3C6bA4cbcd8a54a949Fb83f78 -y
 
-snet service metadata_init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service_type jsonrpc --group_name group1
+snet service metadata_init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1
 snet service metadata_add_endpoints  8.8.8.8:22  1.2.3.4:8080
 snet service metadata_set_fixed_price 0.0001
 snet service publish test2 tests -y -q

--- a/test/functional_tests/script6_organization.sh
+++ b/test/functional_tests/script6_organization.sh
@@ -1,11 +1,20 @@
 # Test "snet organization"
 
 snet organization create test0 -y -q
-snet organization create test1 --members 0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB -y -q
-snet organization create test2 --members 0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB,0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18 -y -q
+
+snet organization create test0 --org-id test0 -y -q
+
+# fail to create organization with the same id
+snet organization create test0 --org-id test0 -y -q && exit 1 || echo "fail as expected"
+
+# create organization with random id
+snet organization create test0 -y -q
+
+snet organization create test1 --org-id test1 --members 0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB -y -q
+snet organization create test2 --org-id test2 --members 0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB,0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18 -y -q
 snet organization add-members test2 0x32267d505B1901236508DcDa64C1D0d5B9DF639a -y
 snet organization add-members test2 0x5c1011aB3C7f46EC5E78073D61DF6d002983F04a,0x42A605c07EdE0E1f648aB054775D6D4E38496144 -y
-snet organization add-members test2 0x5c1011aB3C7f46EC5E78073D61DF6d002983F04a,0x42A605c07EdE0E1f648aB054775D6D4E38496144 -y 2>&1 | grep "No member was added"
+snet organization add-members test2 0x5c1011aB3C7f46EC5E78073D61DF6d002983F04a,0x42A605c07EdE0E1f648aB054775D6D4E38496144 -y | grep "No member was added"
 snet organization add-members test2 0x5c1011aB3C7f46EC5E78073D61DF6d002983F04a,0x42A605c07EdE0E1f648aB054775D6D4E38496144,0xc990EEAad8c943E3C6bA4cbcd8a54a949Fb83f78 -y
 
 snet service metadata_init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service_type jsonrpc --group_name group1
@@ -24,6 +33,7 @@ snet organization rem-members test2 0x42A605c07EdE0E1f648aB054775D6D4E38496144,0
 snet organization rem-members test2 0x42A605c07EdE0E1f648aB054775D6D4E38496144,0xc990EEAad8c943E3C6bA4cbcd8a54a949Fb83f78 -y 2>&1 | grep "No member was removed"
 
 snet organization list
+snet organization list-org-names
 snet organization info test2
 
 snet organization change-owner test2 0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB -y
@@ -39,3 +49,5 @@ snet organization add-members test2 0x32267d505B1901236508DcDa64C1D0d5B9DF639a -
 snet organization delete test2 -y && exit 1 || echo "fail as expected"
 
 snet organization delete test2 --wallet-index 1 -y
+
+snet organization info test2 || echo "fail as expected"

--- a/test/functional_tests/script6_organization.sh
+++ b/test/functional_tests/script6_organization.sh
@@ -1,14 +1,16 @@
 # Test "snet organization"
 
-snet organization create test0 -y -q
-
 snet organization create test0 --org-id test0 -y -q
 
 # fail to create organization with the same id
 snet organization create test0 --org-id test0 -y -q && exit 1 || echo "fail as expected"
 
+# --org-id and --auto are mutually exclusive
+snet organization create test1 --org-id test1 --auto -y -q && exit 1 || echo "fail as expected"
+
+
 # create organization with random id
-snet organization create test0 -y -q
+snet organization create test0 --auto -y -q
 
 snet organization create test1 --org-id test1 --members 0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB -y -q
 snet organization create test2 --org-id test2 --members 0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB,0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18 -y -q
@@ -34,6 +36,8 @@ snet organization rem-members test2 0x42A605c07EdE0E1f648aB054775D6D4E38496144,0
 
 snet organization list
 snet organization list-org-names
+# test2 should be found here
+snet organization list-my | grep test2
 snet organization info test2
 
 snet organization change-owner test2 0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB -y

--- a/test/functional_tests/script6_organization.sh
+++ b/test/functional_tests/script6_organization.sh
@@ -19,9 +19,9 @@ snet organization add-members test2 0x5c1011aB3C7f46EC5E78073D61DF6d002983F04a,0
 snet organization add-members test2 0x5c1011aB3C7f46EC5E78073D61DF6d002983F04a,0x42A605c07EdE0E1f648aB054775D6D4E38496144 -y | grep "No member was added"
 snet organization add-members test2 0x5c1011aB3C7f46EC5E78073D61DF6d002983F04a,0x42A605c07EdE0E1f648aB054775D6D4E38496144,0xc990EEAad8c943E3C6bA4cbcd8a54a949Fb83f78 -y
 
-snet service metadata_init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1
-snet service metadata_add_endpoints  8.8.8.8:22  1.2.3.4:8080
-snet service metadata_set_fixed_price 0.0001
+snet service metadata-init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1
+snet service metadata-add-endpoints  8.8.8.8:22  1.2.3.4:8080
+snet service metadata-set-fixed-price 0.0001
 snet service publish test2 tests -y -q
 snet service publish test2 tests2 -y -q
 snet organization info test2

--- a/test/functional_tests/script6_organization.sh
+++ b/test/functional_tests/script6_organization.sh
@@ -44,8 +44,6 @@ snet organization change-owner test2 0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB 
 snet organization change-owner test2 0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB -y && exit 1 || echo "fail as expected"
 snet organization add-members test2 0x32267d505B1901236508DcDa64C1D0d5B9DF639a -y && exit 1 || echo "fail as expected"
 
-snet identity create __rpc_user rpc --network local
-snet identity __rpc_user
 # this should work because owner is the second account
 snet organization add-members test2 0x32267d505B1901236508DcDa64C1D0d5B9DF639a --wallet-index 1 -y
 

--- a/test/functional_tests/script7_contracts.sh
+++ b/test/functional_tests/script7_contracts.sh
@@ -21,7 +21,7 @@ REZ=`snet contract  MultiPartyEscrow --at 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec
 test $REZ = 2000000
 
 # We set expiration as current_block - 1
-EXPIRATION=$((`snet client block_number` - 1))
+EXPIRATION=$((`snet channel block-number` - 1))
 snet contract MultiPartyEscrow --at 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e openChannel  0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18 0 420000 $EXPIRATION --transact -y
 
 REZ=`snet contract MultiPartyEscrow nextChannelId`

--- a/test/functional_tests/script7_contracts.sh
+++ b/test/functional_tests/script7_contracts.sh
@@ -22,7 +22,7 @@ test $REZ = 2000000
 
 # We set expiration as current_block - 1
 EXPIRATION=$((`snet client block_number` - 1))
-snet contract MultiPartyEscrow --at 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e openChannel  0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB 420000 $EXPIRATION 0 0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB --transact -y
+snet contract MultiPartyEscrow --at 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e openChannel  0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18 0 420000 $EXPIRATION --transact -y
 
 REZ=`snet contract MultiPartyEscrow nextChannelId`
 test $REZ = 1

--- a/test/functional_tests/script7_contracts.sh
+++ b/test/functional_tests/script7_contracts.sh
@@ -1,7 +1,7 @@
 # Test "snet contracts"
 
-snet contract Registry --at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2 createOrganization ExampleOrganization1 '["0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB"]' --transact -y
-snet contract Registry createOrganization ExampleOrganization2 '["0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB","0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18"]' --transact -y
+snet contract Registry --at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2 createOrganization ExampleOrganization1 ExampleOrganization1 '["0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB"]' --transact -y
+snet contract Registry createOrganization ExampleOrganization2 ExampleOrganization2 '["0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB","0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18"]' --transact -y
 snet organization list 2>&1 | grep ExampleOrganization1
 snet organization list 2>&1 | grep ExampleOrganization2
 

--- a/test/functional_tests/script8_networks.sh
+++ b/test/functional_tests/script8_networks.sh
@@ -1,0 +1,16 @@
+# Test "snet network"
+
+snet network create local_bad http://localhost:8080 && exit 1 || echo "fail as expected"
+
+# create network without check
+snet network create local_bad http://localhost:8080 --skip-check
+
+#switch to this network
+snet network local_bad
+
+#switch to mainnet
+snet network mainnet
+
+#switch to kovan
+snet network kovan
+

--- a/test/utils/reset_environment.sh
+++ b/test/utils/reset_environment.sh
@@ -36,14 +36,14 @@ nohup ./node_modules/.bin/ganache-cli --mnemonic 'gauge enact biology destroy no
 rm -rf ~/.snet
 
 # IV. Configure SNET-CLI.
+# Add local network and switch to it
+snet network create local http://localhost:8545
 
 # Create First identity (snet-user = first ganache)
 # We will automatically create new configuration file with default values
-snet identity create snet-user key --private-key 0xc71478a6d0fe44e763649de0a0deb5a080b788eefbbcf9c6f7aef0dd5dbd67e0
+snet identity create snet-user rpc --network local
 
-# Add local network and switch to it
-snet network create local http://localhost:8545
-snet network local
+snet identity snet-user
 
 # set correct ipfs endpoint
 snet set  default_ipfs_endpoint http://localhost:5002


### PR DESCRIPTION
This PR does following:
* adapt snet-cli for new platform-contracts (https://github.com/singnet/platform-contracts/pull/84 and https://github.com/singnet/platform-contracts/pull/84)
     * In ```snet create organization``` by default user should specify only org_name. In this case org_id will be generated automatically. 
     * org_id is specified in string format (similar to old organization name in previous version)
     * User can specify org_id by hands: ```snet create organization myOrgName --org-id myOrgId```
     * service_name was renamed to service_id (but there is not API change here)
     * In all function (except ```snet organization create```) user should specify org_id and service_id (not org_name and service_display_name).
     * org_id is printed in the last line of ```snet create organization```, so user can easily save it and use in the following functions.
```
ORG_ID=`snet organization create myOrgName -y -q | tail -1`
# now we can use $ORG_ID
snet organization add-members $ORG_ID 0x32267d505B1901236508DcDa64C1D0d5B9DF639a -y
snet service publish $ORG_ID MyServiceID 
```

* Add --skip-check in ```snet network create``` (fix #143)
* Add CI for ```snet network```

CI will be green for new release of platform-contracts.