### PR TITLE
Fix events filtering on kovan

### DIFF
--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -493,12 +493,16 @@ def add_mpe_channel_options(parser):
     def add_p_from_block(p):
         p.add_argument("--from-block", type=int, default=0, help="Start searching from this block")
 
+    def add_p_sender(p):
+        p.add_argument("--sender", default=None, help="Account to set as sender (by default we use the current identity)")
+
     p = subparsers.add_parser("print-all-filter-sender", help="Print all channels for the given sender.")
     p.set_defaults(fn="print_all_channels_filter_sender")
     add_p_only_id(p)
     add_p_mpe_address_opt(p)
     add_p_from_block(p)
     add_eth_call_arguments(p)
+    add_p_sender(p)
 
     p = subparsers.add_parser("print-all-filter-recipient", help="Print all channels for the given recipient.")
     p.set_defaults(fn="print_all_channels_filter_recipient")
@@ -506,6 +510,7 @@ def add_mpe_channel_options(parser):
     add_p_mpe_address_opt(p)
     add_p_from_block(p)
     add_eth_call_arguments(p)
+    p.add_argument("--recipient", default=None, help="Account to set as recipient (by default we use the current identity)")
 
     p = subparsers.add_parser("print-all-filter-group", help="Print all channels for the given service.")
     p.set_defaults(fn="print_all_channels_filter_group")
@@ -524,6 +529,7 @@ def add_mpe_channel_options(parser):
     add_p_mpe_address_opt(p)
     add_p_from_block(p)
     add_eth_call_arguments(p)
+    add_p_sender(p)
 
 
 def add_mpe_client_options(parser):

--- a/snet_cli/mpe_channel_command.py
+++ b/snet_cli/mpe_channel_command.py
@@ -218,13 +218,20 @@ class MPEChannelCommand(MPEServiceCommand):
         channels_ids  = [get_event_data(event_abi, l)["args"]["channelId"] for l in logs]
         return channels_ids
 
+    def get_address_from_arg_or_ident(self, arg):
+        if (arg):
+            return arg
+        return self.ident.address
+
     def print_all_channels_filter_sender(self):
-        address_padded = pad_hex(self.ident.address.lower(), 256)
+        address = self.get_address_from_arg_or_ident(self.args.sender)
+        address_padded = pad_hex(address.lower(), 256)
         channels_ids = self._get_all_filtered_channels([address_padded])
         self._print_channels_from_blockchain(channels_ids)
 
     def print_all_channels_filter_recipient(self):
-        address_padded = pad_hex(self.ident.address.lower(), 256)
+        address = self.get_address_from_arg_or_ident(self.args.recipient)
+        address_padded = pad_hex(address.lower(), 256)
         channels_ids = self._get_all_filtered_channels([None,address_padded])
         self._print_channels_from_blockchain(channels_ids)
 
@@ -236,7 +243,8 @@ class MPEChannelCommand(MPEServiceCommand):
         self._print_channels_from_blockchain(channels_ids)
 
     def print_all_channels_filter_group_sender(self):
-        address_padded = pad_hex(self.ident.address.lower(), 256)
+        address = self.get_address_from_arg_or_ident(self.args.sender)
+        address_padded = pad_hex(address.lower(), 256)
         metadata = self._get_service_metadata_from_registry()
         group_id = metadata.get_group_id(self.args.group_name)
         group_id_hex = "0x" + group_id.hex()

--- a/snet_cli/mpe_channel_command.py
+++ b/snet_cli/mpe_channel_command.py
@@ -10,7 +10,9 @@ import shutil
 import tempfile
 from snet_cli.utils_agi2cogs import cogs2stragi
 import pickle
-from snet_cli.contract import Contract
+from web3.utils.encoding import pad_hex
+from web3.utils.events import get_event_data
+
 
 # we inherit MPEServiceCommand because we need _get_service_metadata_from_registry
 class MPEChannelCommand(MPEServiceCommand):
@@ -206,33 +208,39 @@ class MPEChannelCommand(MPEServiceCommand):
         self._print_channels_from_blockchain(good_ids)
 
     # function for get all filtered chanels from blockchain logs
-    def _get_all_filtered_channels(self, argument_filters, from_block):
-        mpe_address = self.get_mpe_address()
-        abi = get_contract_def("MultiPartyEscrow")["abi"]
-        contract = Contract(self.w3, mpe_address, abi)
-        contract = contract.contract
-        filter = contract.events.ChannelOpen.createFilter(fromBlock=from_block, argument_filters=argument_filters)
-        events = filter.get_all_entries()
-        return [e["args"]["channelId"] for e in events]
+    def _get_all_filtered_channels(self, topics_without_signature):
+        mpe_address     = self.get_mpe_address()
+        event_signature = self.ident.w3.sha3(text="ChannelOpen(uint256,uint256,address,address,address,bytes32,uint256,uint256)").hex()
+        topics = [event_signature] + topics_without_signature
+        logs = self.ident.w3.eth.getLogs({"fromBlock" : self.args.from_block, "address"   : mpe_address, "topics"    : topics})
+        abi           = get_contract_def("MultiPartyEscrow")
+        event_abi     = abi_get_element_by_name(abi, "ChannelOpen")
+        channels_ids  = [get_event_data(event_abi, l)["args"]["channelId"] for l in logs]
+        return channels_ids
 
     def print_all_channels_filter_sender(self):
-        channels_ids = self._get_all_filtered_channels({"sender":self.ident.address}, self.args.from_block)
+        address_padded = pad_hex(self.ident.address.lower(), 256)
+        channels_ids = self._get_all_filtered_channels([address_padded])
         self._print_channels_from_blockchain(channels_ids)
 
     def print_all_channels_filter_recipient(self):
-        channels_ids = self._get_all_filtered_channels({"recipient":self.ident.address}, self.args.from_block)
+        address_padded = pad_hex(self.ident.address.lower(), 256)
+        channels_ids = self._get_all_filtered_channels([None,address_padded])
         self._print_channels_from_blockchain(channels_ids)
 
     def print_all_channels_filter_group(self):
         metadata = self._get_service_metadata_from_registry()
         group_id = metadata.get_group_id(self.args.group_name)
-        channels_ids = self._get_all_filtered_channels({"groupId": group_id}, self.args.from_block)
+        group_id_hex = "0x" + group_id.hex()
+        channels_ids = self._get_all_filtered_channels([None, None, group_id_hex])
         self._print_channels_from_blockchain(channels_ids)
 
     def print_all_channels_filter_group_sender(self):
+        address_padded = pad_hex(self.ident.address.lower(), 256)
         metadata = self._get_service_metadata_from_registry()
         group_id = metadata.get_group_id(self.args.group_name)
-        channels_ids = self._get_all_filtered_channels({"groupId": group_id, "sender": self.ident.address}, self.args.from_block)
+        group_id_hex = "0x" + group_id.hex()
+        channels_ids = self._get_all_filtered_channels([address_padded, None, group_id_hex])
         self._print_channels_from_blockchain(channels_ids)
 
     #Auxilary functions

--- a/test/functional_tests/script1_twogroups.sh
+++ b/test/functional_tests/script1_twogroups.sh
@@ -99,6 +99,7 @@ snet channel print-all-filter-sender | grep 0x52653A9091b5d5021bed06c5118D24b236
 
 snet channel print-all-filter-recipient | grep 0x52653A9091b5d5021bed06c5118D24b23620c529 && exit 1 || echo "fail as expected"
 snet channel print-all-filter-recipient --wallet-index 9 |grep 0x52653A9091b5d5021bed06c5118D24b23620c529
+snet channel print-all-filter-recipient --recipient 0x52653A9091b5d5021bed06c5118D24b23620c529 |grep 0x52653A9091b5d5021bed06c5118D24b23620c529
 
 snet channel print-all-filter-group testo tests2 | grep 0x52653A9091b5d5021bed06c5118D24b23620c529
 snet channel print-all-filter-group testo tests2 | grep 0x42A605c07EdE0E1f648aB054775D6D4E38496144 && exit 1 || echo "fail as expected"
@@ -114,3 +115,12 @@ snet channel print-initialized
 snet channel print-all-filter-sender
 snet service delete testo tests -y -q
 snet organization list-services testo
+
+# open channel with sender=signer=0x32267d505B1901236508DcDa64C1D0d5B9DF639a
+
+snet account transfer 0x32267d505B1901236508DcDa64C1D0d5B9DF639a 1 -y -q
+snet channel open-init testo tests2 1 314156700003452 -y  -q --wallet-index 3
+snet channel print-all-filter-sender --sender 0x32267d505B1901236508DcDa64C1D0d5B9DF639a |grep 314156700003452
+snet channel print-all-filter-sender |grep 314156700003452 && exit 1 || echo "fail as expected"
+
+snet channel print-all-filter-group-sender testo tests2 --sender 0x32267d505B1901236508DcDa64C1D0d5B9DF639a |grep 314156700003452


### PR DESCRIPTION
This PR fix issue with even filtering on kovan. 

* Switch to low-level even filtering interface (high-level for some reason didn't work on kovan)
* Add ```--sender``` for ```snet channel  print-all-filter-sender```. 
* Add ```--recipient``` for ```snet channel print-all-filter-recipient``` and ```snet channel print-all-filter-group-sender```
