### PR TITLE
Fix issues 144 and 154

### DIFF
--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -595,14 +595,19 @@ def add_mpe_service_options(parser):
     p.add_argument("--group-name", default=None, help="name of the payment group to which we want to add endpoints. Parameter should be specified in case of several payment groups")
     add_p_metadata_file_opt(p)
 
+    def add_p_publish_params(p):
+        add_p_metadata_file_opt(p)
+        p.add_argument("--update-mpe-address" , action='store_true', help="Update mpe_address in metadata before publishing them")
+        add_p_mpe_address_opt(p)
+
     p = subparsers.add_parser("publish-in-ipfs", help="Publish metadata only in IPFS, without publising in Registry")
     p.set_defaults(fn="publish_metadata_in_ipfs")
-    add_p_metadata_file_opt(p)
+    add_p_publish_params(p)
 
     p = subparsers.add_parser("publish", help="Publish service with given metadata")
     p.set_defaults(fn="publish_service_with_metadata")
+    add_p_publish_params(p)
     add_p_service_in_registry(p)
-    add_p_metadata_file_opt(p)
     p.add_argument("--tags", nargs="*", default=[], help="tags for service")
     add_transaction_arguments(p)
 

--- a/snet_cli/mpe_service_command.py
+++ b/snet_cli/mpe_service_command.py
@@ -64,7 +64,7 @@ class MPEServiceCommand(BlockchainCommand):
             raise Exception("\n\nmpe_address in metadata does not correspond to the current MultiPartyEscrow contract address\n" +
                             "You have two possibilities:\n" +
                             "1. You can use --multipartyescrow-at to set current mpe address\n" +
-                            "2. You can use --updata-mpe-address parameter to update mpe_address in metadata before publishing it\n")
+                            "2. You can use --update-mpe-address parameter to update mpe_address in metadata before publishing it\n")
         return self._get_ipfs_client().add_bytes(metadata.get_json().encode("utf-8"))
 
     # publish metadata in ipfs and print hash

--- a/snet_cli/mpe_service_command.py
+++ b/snet_cli/mpe_service_command.py
@@ -60,7 +60,7 @@ class MPEServiceCommand(BlockchainCommand):
             metadata.set_simple_field("mpe_address",  mpe_address)
             metadata.save_pretty(self.args.metadata_file)
 
-        if (mpe_address != metadata["mpe_address"]):
+        if (mpe_address.lower() != metadata["mpe_address"].lower()):
             raise Exception("\n\nmpe_address in metadata does not correspond to the current MultiPartyEscrow contract address\n" +
                             "You have two possibilities:\n" +
                             "1. You can use --multipartyescrow-at to set current mpe address\n" +

--- a/snet_cli/mpe_service_command.py
+++ b/snet_cli/mpe_service_command.py
@@ -55,6 +55,16 @@ class MPEServiceCommand(BlockchainCommand):
 
     def _publish_metadata_in_ipfs(self, metadata_file):
         metadata = load_mpe_service_metadata(metadata_file)
+        mpe_address = self.get_mpe_address()
+        if (self.args.update_mpe_address):
+            metadata.set_simple_field("mpe_address",  mpe_address)
+            metadata.save_pretty(self.args.metadata_file)
+
+        if (mpe_address != metadata["mpe_address"]):
+            raise Exception("\n\nmpe_address in metadata does not correspond to the current MultiPartyEscrow contract address\n" +
+                            "You have two possibilities:\n" +
+                            "1. You can use --multipartyescrow-at to set current mpe address\n" +
+                            "2. You can use --updata-mpe-address parameter to update mpe_address in metadata before publishing it\n")
         return self._get_ipfs_client().add_bytes(metadata.get_json().encode("utf-8"))
 
     # publish metadata in ipfs and print hash

--- a/test/functional_tests/script1_twogroups.sh
+++ b/test/functional_tests/script1_twogroups.sh
@@ -124,3 +124,26 @@ snet channel print-all-filter-sender --sender 0x32267d505B1901236508DcDa64C1D0d5
 snet channel print-all-filter-sender |grep 314156700003452 && exit 1 || echo "fail as expected"
 
 snet channel print-all-filter-group-sender testo tests2 --sender 0x32267d505B1901236508DcDa64C1D0d5B9DF639a |grep 314156700003452
+
+# test migration to different network
+
+# get service metadata from registry and set mpe_address to wrong value
+snet service print-metadata  testo tests2 | jq '.mpe_address = "0x52653A9091b5d5021bed06c5118D24b23620c529"' > service_metadata.json
+
+# this should fail because of wrong mpe_address
+snet service publish-in-ipfs && exit 1 || echo "fail as expected"
+
+snet service publish-in-ipfs --multipartyescrow-at 0x52653A9091b5d5021bed06c5118D24b23620c529
+snet service publish-in-ipfs && exit 1 || echo "fail as expected"
+snet service publish-in-ipfs --update-mpe-address
+snet service publish-in-ipfs
+
+snet service print-metadata  testo tests2 | jq '.mpe_address = "0x52653A9091b5d5021bed06c5118D24b23620c529"' > service_metadata.json
+
+# this should fail because of wrong mpe_address
+snet service publish testo tests4 && exit 1 || echo "fail as expected"
+
+snet service publish testo tests4 --multipartyescrow-at 0x52653A9091b5d5021bed06c5118D24b23620c529 -yq
+snet service publish testo tests5 -yq && exit 1 || echo "fail as expected"
+snet service publish testo tests6 --update-mpe-address -yq
+snet service publish testo tests7 -yq

--- a/test/functional_tests/script3_without_addresses.sh
+++ b/test/functional_tests/script3_without_addresses.sh
@@ -22,14 +22,14 @@ snet service metadata-add-group group2 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a1
 snet service metadata-add-endpoints  8.8.8.8:2020 9.8.9.8:8080 --group-name group1
 snet service metadata-add-endpoints  8.8.8.8:22   1.2.3.4:8080 --group-name group2
 snet service metadata-set-fixed-price 0.0001
-IPFS_HASH=$(snet service publish-in-ipfs)
+IPFS_HASH=$(snet service publish-in-ipfs --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e)
 ipfs cat $IPFS_HASH > service_metadata2.json
 
 # compare service_metadata.json and service_metadata2.json
 cmp <(jq -S . service_metadata.json) <(jq -S . service_metadata2.json)
 
 snet organization create testo --org-id testo -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
-snet service publish testo tests -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
+snet service publish testo tests -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet service update-add-tags testo tests tag1 tag2 tag3 -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet service update-remove-tags testo tests tag2 tag1 -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet service print-tags  testo tests --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2

--- a/test/utils/reset_environment.sh
+++ b/test/utils/reset_environment.sh
@@ -36,20 +36,22 @@ nohup ./node_modules/.bin/ganache-cli --mnemonic 'gauge enact biology destroy no
 rm -rf ~/.snet
 
 # IV. Configure SNET-CLI.
+
+# set correct ipfs endpoint
+# (the new new configuration file with default values will be created automatically)
+snet set  default_ipfs_endpoint http://localhost:5002
+
 # Add local network and switch to it
 snet network create local http://localhost:8545
 
-# Create First identity (snet-user = first ganache)
-# We will automatically create new configuration file with default values
-snet identity create snet-user rpc --network local
-
-snet identity snet-user
-
-# set correct ipfs endpoint
-snet set  default_ipfs_endpoint http://localhost:5002
-
+# swith to local network
+snet network local
 
 # Configure contract addresses for local network (it will not be necessary for kovan or mainnet! )
 snet set current_singularitynettoken_at 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14
 snet set current_registry_at            0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet set current_multipartyescrow_at    0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+
+# Create First identity (snet-user = first ganache).
+# (snet will automatically swith to this new identity)
+snet identity create snet-user rpc --network local


### PR DESCRIPTION
In this PR we fix issues #144  and #154 

* Add possibility to call ```snet set default_ipfs_endpoint``` and ```snet set current_*_at``` before creating first identity
* Forbid to publish service with wrong mpe_address in metadata. It will print the following warning:
```
mpe_address in metadata does not correspond to the current MultiPartyEscrow contract address
You have two possibilities:
1. You can use --multipartyescrow-at to set current mpe address
2. You can use --update-mpe-address parameter to update mpe_address in metadata before publishing it
```

* add option  ```--update-mpe-address``` for ```snet service publish``` and ```snet service publish-in-ipfs```