### PR TITLE
Add snet service_description field in metadata

### DIFF
--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -595,6 +595,11 @@ def add_mpe_service_options(parser):
     p.add_argument("--group-name", default=None, help="name of the payment group to which we want to add endpoints. Parameter should be specified in case of several payment groups")
     add_p_metadata_file_opt(p)
 
+    p = subparsers.add_parser("metadata-add-description-json", help="Add service description")
+    p.set_defaults(fn="metadata_add_description_json")
+    p.add_argument("json", default=None, help="Service description in json")
+    add_p_metadata_file_opt(p)
+
     def add_p_publish_params(p):
         add_p_metadata_file_opt(p)
         p.add_argument("--update-mpe-address" , action='store_true', help="Update mpe_address in metadata before publishing them")

--- a/snet_cli/mpe_service_command.py
+++ b/snet_cli/mpe_service_command.py
@@ -4,6 +4,7 @@ from snet_cli.mpe_service_metadata import MPEServiceMetadata, load_mpe_service_m
 from snet_cli.utils import type_converter, bytes32_to_str
 from snet_cli.utils_ipfs import hash_to_bytesuri, bytesuri_to_hash, get_from_ipfs_and_checkhash, safe_extract_proto_from_ipfs
 import web3
+import json
 
 class MPEServiceCommand(BlockchainCommand):
 
@@ -51,6 +52,12 @@ class MPEServiceCommand(BlockchainCommand):
         group_name = metadata.get_group_name_nonetrick(self.args.group_name)
         for endpoint in self.args.endpoints:
             metadata.add_endpoint(group_name, endpoint)
+        metadata.save_pretty(self.args.metadata_file)
+
+    # metadata add description
+    def metadata_add_description_json(self):
+        metadata = load_mpe_service_metadata(self.args.metadata_file)
+        metadata.set_simple_field("service_description", json.loads(self.args.json))
         metadata.save_pretty(self.args.metadata_file)
 
     def _publish_metadata_in_ipfs(self, metadata_file):

--- a/snet_cli/mpe_service_command.py
+++ b/snet_cli/mpe_service_command.py
@@ -48,7 +48,6 @@ class MPEServiceCommand(BlockchainCommand):
     # metadata add endpoint to the group
     def metadata_add_endpoints(self):
         metadata = load_mpe_service_metadata(self.args.metadata_file)
-        metadata.load(self.args.metadata_file)
         group_name = metadata.get_group_name_nonetrick(self.args.group_name)
         for endpoint in self.args.endpoints:
             metadata.add_endpoint(group_name, endpoint)

--- a/test/functional_tests/script1_twogroups.sh
+++ b/test/functional_tests/script1_twogroups.sh
@@ -8,6 +8,7 @@ snet service metadata-init ./ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E3
 
 # happy flow
 snet service metadata-init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1
+snet service metadata-add-description-json '{"description_string":"string1","description_int":1,"description_dict":{"a":1,"b":"s"}}'
 snet service metadata-add-group group2 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18
 snet service metadata-add-endpoints  8.8.8.8:2020 9.8.9.8:8080 --group-name group1
 snet service metadata-add-endpoints  8.8.8.8:22   1.2.3.4:8080 --group-name group2


### PR DESCRIPTION
This PR solves #150.

It adds "snet service metadata-add-description-json" to add service_description field in metadata. Description should be passed in json format. For example: 
```
snet service metadata-add-description-json '{"description_string":"string1","description_int":1,"description_dict":{"a":1,"b":"s"}}'
```
