### PR TITLE
Treasurer server

### DIFF
--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -11,6 +11,7 @@ from snet_cli.mpe_account_command import MPEAccountCommand
 from snet_cli.mpe_service_command import MPEServiceCommand
 from snet_cli.mpe_channel_command import MPEChannelCommand
 from snet_cli.mpe_client_command  import MPEClientCommand
+from snet_cli.mpe_treasurer_command import MPETreasurerCommand
 from snet_cli.utils_agi2cogs import stragi2cogs
 from snet_cli.config import get_session_keys, get_session_network_keys_removable
 
@@ -85,6 +86,9 @@ def add_root_options(parser, config):
 
     mpe_server_p = subparsers.add_parser("service", help="Create, publish, register, and update SingularityNET services")
     add_mpe_service_options(mpe_server_p)
+
+    p = subparsers.add_parser("treasurer", help="Treasurer logic")
+    add_mpe_treasurer_options(p)
 
 
 def add_version_options(parser):
@@ -653,4 +657,34 @@ def add_mpe_service_options(parser):
     p = subparsers.add_parser("delete", help="Delete service registration from registry")
     p.set_defaults(fn="delete_service_registration")
     add_p_service_in_registry(p)
+    add_transaction_arguments(p)
+
+def add_mpe_treasurer_options(parser):
+    parser.set_defaults(cmd=MPETreasurerCommand)
+    subparsers = parser.add_subparsers(title="Commands", metavar="COMMAND")
+    subparsers.required = True
+
+    def add_p_endpoint(p):
+        p.add_argument("--endpoint", required=True, help="daemon endpoint")
+
+
+    p = subparsers.add_parser("print-unclaimed", help="Print unclaimed payments")
+    p.set_defaults(fn="print_unclaimed")
+    add_p_endpoint(p)
+
+    p = subparsers.add_parser("claim", help="Claim given channels. We also claim all pending 'payments in progress' in case we 'lost' some payments.")
+    p.set_defaults(fn="claim_channels")
+    p.add_argument("channels", type=int, nargs="+", help="channels to claim")
+    add_p_endpoint(p)
+    add_transaction_arguments(p)
+
+    p = subparsers.add_parser("claim-all", help="Claim all channels. We also claim all pending 'payments in progress' in case we 'lost' some payments.")
+    p.set_defaults(fn="claim_all_channels")
+    add_p_endpoint(p)
+    add_transaction_arguments(p)
+
+    p = subparsers.add_parser("claim-expired", help="Claim all channels which are close to expiration date. We also claim all pending 'payments in progress' in case we 'lost' some payments.")
+    p.set_defaults(fn="claim_almost_expired_channels")
+    p.add_argument("--expiration-threshold", type=int, default = 34560, help="Service expiration threshold in blocks (default is 34560 ~ 6 days with 15s/block)")
+    add_p_endpoint(p)
     add_transaction_arguments(p)

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -671,6 +671,7 @@ def add_mpe_treasurer_options(parser):
     p = subparsers.add_parser("print-unclaimed", help="Print unclaimed payments")
     p.set_defaults(fn="print_unclaimed")
     add_p_endpoint(p)
+    add_eth_call_arguments(p)
 
     p = subparsers.add_parser("claim", help="Claim given channels. We also claim all pending 'payments in progress' in case we 'lost' some payments.")
     p.set_defaults(fn="claim_channels")

--- a/snet_cli/mpe_treasurer_command.py
+++ b/snet_cli/mpe_treasurer_command.py
@@ -1,0 +1,158 @@
+from snet_cli.mpe_channel_command import MPEChannelCommand
+from snet_cli.utils import compile_proto
+from pathlib import Path
+import sys
+import os
+import grpc
+from eth_account.messages import defunct_hash_message
+from snet_cli.utils_proto import import_protobuf_from_dir
+from snet_cli.utils import int4bytes_big
+from snet_cli.utils_agi2cogs import cogs2stragi
+import web3
+
+
+# we inherit MPEChannelCommand because we need _get_channel_state_from_blockchain
+class MPETreasurerCommand(MPEChannelCommand):
+
+    def _sign_message_list_unclaimed(self, mpe_address, current_block):
+        message =  self.w3.soliditySha3(
+                        ["string",           "address",   "uint256"],
+                        ["__list_unclaimed", mpe_address, current_block])
+        return self.ident.sign_message_after_soliditySha3(message)
+    def _sign_message_list_in_progress(self, mpe_address, current_block):
+        message =  self.w3.soliditySha3(
+                        ["string",             "address",   "uint256"],
+                        ["__list_in_progress", mpe_address, current_block])
+        return self.ident.sign_message_after_soliditySha3(message)
+
+    def _sign_message_start_claim(self, mpe_address, channel_id, channel_nonce):
+        message =  self.w3.soliditySha3(
+                        ["string",           "address",   "uint256",  "uint256"],
+                        ["__start_claim", mpe_address,   channel_id,   channel_nonce])
+        return self.ident.sign_message_after_soliditySha3(message)
+
+    # import protobuf and return stub and request class
+    def _get_stub_and_request_classes(self, service_name):
+        # Compile protobuf if needed
+        codegen_dir = Path.home().joinpath(".snet", "mpe_client", "control_service")
+        proto_dir   = Path(__file__).absolute().parent.joinpath("resources", "proto")
+        if (not codegen_dir.joinpath("control_service_pb2.py").is_file()):
+            compile_proto(proto_dir, codegen_dir, proto_file = "control_service.proto")
+
+        stub_class, request_class, _ = import_protobuf_from_dir(codegen_dir, service_name)
+        return stub_class, request_class
+
+    def _decode_PaymentReply(self, p):
+        return {"channel_id" :  int4bytes_big(p.channel_id), "nonce" : int4bytes_big(p.channel_nonce), "amount" : int4bytes_big(p.signed_amount), "signature" : p.signature}
+
+    def _call_GetListUnclaimed(self, grpc_channel):
+        stub_class, request_class = self._get_stub_and_request_classes("GetListUnclaimed")
+        stub     = stub_class(grpc_channel)
+
+        mpe_address = self.get_mpe_address()
+        current_block = self.ident.w3.eth.blockNumber
+        signature = self._sign_message_list_unclaimed(mpe_address, current_block)
+        request = request_class(mpe_address = mpe_address, current_block = current_block, signature = bytes(signature))
+        response = getattr(stub, "GetListUnclaimed")(request)
+
+        for p in response.payments:
+            if (len(p.signature) > 0):
+                raise Exception("Signature was set in GetListUnclaimed. Response is invalid")
+
+        return [self._decode_PaymentReply(p) for p in response.payments]
+
+    def _call_GetListInProgress(self, grpc_channel):
+        stub_class, request_class = self._get_stub_and_request_classes("GetListInProgress")
+        stub     = stub_class(grpc_channel)
+
+        mpe_address = self.get_mpe_address()
+        current_block = self.ident.w3.eth.blockNumber
+        signature = self._sign_message_list_in_progress(mpe_address, current_block)
+        request = request_class(mpe_address = mpe_address, current_block = current_block, signature = bytes(signature))
+        response = getattr(stub, "GetListInProgress")(request)
+        return [self._decode_PaymentReply(p) for p in response.payments]
+
+    def _call_StartClaim(self, grpc_channel, channel_id, channel_nonce):
+        stub_class, request_class = self._get_stub_and_request_classes("StartClaim")
+        stub     = stub_class(grpc_channel)
+        mpe_address = self.get_mpe_address()
+        signature =  self._sign_message_start_claim(mpe_address, channel_id, channel_nonce)
+        request = request_class(mpe_address = mpe_address, channel_id = web3.Web3.toBytes(channel_id), signature = bytes(signature))
+        response = getattr(stub, "StartClaim")(request)
+        return self._decode_PaymentReply(response)
+
+    def print_unclaimed(self):
+        grpc_channel     = grpc.insecure_channel(self.args.endpoint)
+        payments = self._call_GetListUnclaimed(grpc_channel)
+        self._printout("# channel_id  channel_nonce  signed_amount (AGI)")
+        total = 0
+        for p in payments:
+            self._printout("%i   %i   %s"%(p["channel_id"], p["nonce"], cogs2stragi(p["amount"])))
+            total += p["amount"]
+        self._printout("# total_unclaimed_in_AGI = %s"%cogs2stragi(total))
+
+    def _blockchain_claim(self, payments):
+        for payment in payments:
+            channel_id = payment["channel_id"]
+            amount     = payment["amount"]
+            sig        = payment["signature"]
+            v, r, s = int(sig[-1]), sig[:32], sig[32:64]
+            v = v % 27 + 27
+            params     = [channel_id, amount, v , r, s, False]
+            self.transact_contract_command("MultiPartyEscrow", "channelClaim", params)
+
+    # safely run StartClaim for given channels
+    def _start_claim_channels(self, grpc_channel, channels_ids):
+        unclaimed_payments = self._call_GetListUnclaimed(grpc_channel)
+        unclaimed_payments_dict = {p["channel_id"] : p for p in unclaimed_payments}
+
+        to_claim = []
+        for channel_id in channels_ids:
+            if (channel_id not in unclaimed_payments_dict or unclaimed_payments_dict[channel_id]["amount"] == 0):
+                self._printout("There is nothing to claim for channel %i, we skip it"%channel_id)
+                continue
+            blockchain = self._get_channel_state_from_blockchain(channel_id)
+            if (unclaimed_payments_dict[channel_id]["nonce"] != blockchain["nonce"]):
+                self._printout("Old payment for channel %i is still in progress. Please run claim for this channel later."%channel_id)
+                continue
+            to_claim.append((channel_id,  blockchain["nonce"]))
+
+        payments = [self._call_StartClaim(grpc_channel, channel_id, nonce) for channel_id, nonce in to_claim]
+        return payments
+
+    # we claim all 'pending' payments in progress and after we claim given channels
+    def _claim_in_progress_and_claim_channels(self, grpc_channel, channels):
+        # first we get the list of all 'payments in progress' in case we 'lost' some payments.
+        payments = self._call_GetListInProgress(grpc_channel)
+        if (len(payments) > 0):
+            self._printout("There are %i payments in 'progress' (they haven't been claimed in blockchain). We will claim them."%len(payments))
+            self._blockchain_claim(payments)
+        payments = self._start_claim_channels(grpc_channel, channels)
+        self._blockchain_claim(payments)
+
+    def claim_channels(self):
+        grpc_channel     = grpc.insecure_channel(self.args.endpoint)
+        self._claim_in_progress_and_claim_channels(grpc_channel, self.args.channels)
+
+    def claim_all_channels(self):
+        grpc_channel     = grpc.insecure_channel(self.args.endpoint)
+        # we take list of all channels
+        unclaimed_payments = self._call_GetListUnclaimed(grpc_channel)
+        channels = [p["channel_id"] for p in unclaimed_payments]
+        self._claim_in_progress_and_claim_channels(grpc_channel, channels)
+
+    def claim_almost_expired_channels(self):
+        grpc_channel     = grpc.insecure_channel(self.args.endpoint)
+        # we take list of all channels
+        unclaimed_payments = self._call_GetListUnclaimed(grpc_channel)
+
+        channels = []
+        for p in unclaimed_payments:
+            if (p["amount"] == 0):
+                continue
+            channel_id = p["channel_id"]
+            blockchain = self._get_channel_state_from_blockchain(channel_id)
+            if (blockchain["expiration"] < self.ident.w3.eth.blockNumber + self.args.expiration_threshold):
+                self._printout("We are going to claim channel %i"%channel_id)
+                channels.append(channel_id)
+        self._claim_in_progress_and_claim_channels(grpc_channel, channels)

--- a/snet_cli/mpe_treasurer_command.py
+++ b/snet_cli/mpe_treasurer_command.py
@@ -96,6 +96,8 @@ class MPETreasurerCommand(MPEChannelCommand):
             channel_id = payment["channel_id"]
             amount     = payment["amount"]
             sig        = payment["signature"]
+            if (len(sig) != 65):
+                raise Exception("Length of signature is incorect: %i instead of 65"%(len(sig)))
             v, r, s = int(sig[-1]), sig[:32], sig[32:64]
             v = v % 27 + 27
             params     = [channel_id, amount, v , r, s, False]

--- a/snet_cli/resources/proto/control_service.proto
+++ b/snet_cli/resources/proto/control_service.proto
@@ -1,0 +1,55 @@
+syntax = "proto3";
+
+package escrow;
+
+service ProviderControlService {
+
+    //get list of all unclaimed "payments".
+    //in PaymentsSignatureReply signatures MUST be omited
+    //if signature field is present then response should be considered as invalid
+    rpc GetListUnclaimed(GetPaymentsListRequest)  returns (PaymentsListReply) {}
+
+    //get list of all payments in progress
+    rpc GetListInProgress(GetPaymentsListRequest) returns (PaymentsListReply) {}
+
+    //initilize claim for specific channel
+    rpc StartClaim(StartClaimRequest) returns (PaymentReply) {}
+}
+
+
+message GetPaymentsListRequest {
+    //address of MultiPartyEscrow contract
+    string mpe_address = 1;
+    //current block number (signature will be valid only for short time around this block number)
+    uint64 current_block = 2;
+    //signature of the following message:
+    //for GetListUnclaimed ("__list_unclaimed", mpe_address, current_block_number)
+    //for GetListInProgress ("__list_in_progress", mpe_address, current_block_number)
+    bytes signature = 3;
+}
+
+message StartClaimRequest {
+    //address of MultiPartyEscrow contract
+    string mpe_address = 1;
+    //channel_id contains id of the channel which state is requested.
+    bytes channel_id = 2;
+    //signature of the following message ("__start_claim", mpe_address, channel_id, channel_nonce)
+    bytes signature = 3;
+}
+
+message PaymentReply {
+    bytes channel_id    = 1;
+
+    bytes channel_nonce = 2;
+
+    bytes signed_amount = 3;
+
+    //this filed must be OMITED in GetListUnclaimed request
+    bytes signature = 4;
+}
+
+message PaymentsListReply {
+    repeated PaymentReply payments = 1;
+}
+
+

--- a/snet_cli/utils.py
+++ b/snet_cli/utils.py
@@ -173,3 +173,6 @@ def abi_get_element_by_name(abi, name):
 def abi_decode_struct_to_dict(abi, struct_list):
     return {el_abi["name"] : el for el_abi, el in zip(abi["outputs"], struct_list)}
 
+
+def int4bytes_big(b):
+    return int.from_bytes(b, byteorder='big')

--- a/test/functional_tests/script9_treasurer.sh
+++ b/test/functional_tests/script9_treasurer.sh
@@ -1,0 +1,62 @@
+# Test 'snet treasurer'
+
+# run daemon
+cd simple_daemon
+python test_simple_daemon.py &
+DAEMON=$!
+cd ..
+
+
+snet account deposit 12345 -y -q
+
+# service provider has --wallet-index==9 (0x52653A9091b5d5021bed06c5118D24b23620c529)
+snet service metadata-init ./service_spec1/ ExampleService 0x52653A9091b5d5021bed06c5118D24b23620c529 --fixed-price 0.0001 --endpoints 127.0.0.1:50051
+
+
+assert_balance () {
+MPE_BALANCE=$(snet account balance --account 0x52653A9091b5d5021bed06c5118D24b23620c529 |grep MPE)
+test ${MPE_BALANCE##*:} = $1
+}
+
+EXPIRATION0=$((`snet channel block-number` + 100))
+EXPIRATION1=$((`snet channel block-number` + 100000))
+EXPIRATION2=$((`snet channel block-number` + 100000))
+snet channel open-init-metadata 1 $EXPIRATION0 -yq
+snet channel open-init-metadata 1 $EXPIRATION1 -yq
+snet channel open-init-metadata 1 $EXPIRATION2 -yq
+
+snet client call 0 0.0001 127.0.0.1:50051 classify {}
+snet client call 0 0.0001 127.0.0.1:50051 classify {}
+snet client call 1 0.0001 127.0.0.1:50051 classify {}
+snet client call 2 0.0001 127.0.0.1:50051 classify {}
+snet treasurer claim-all --endpoint 127.0.0.1:50051  --wallet-index 9 -yq
+snet treasurer claim-all --endpoint 127.0.0.1:50051  --wallet-index 9 -yq
+assert_balance 0.0004
+snet client call 0 0.0001 127.0.0.1:50051 classify {}
+snet client call 0 0.0001 127.0.0.1:50051 classify {}
+snet client call 1 0.0001 127.0.0.1:50051 classify {}
+snet client call 2 0.0001 127.0.0.1:50051 classify {}
+
+#only channel 0 should be claimed
+snet treasurer claim-expired --expiration-threshold 1000 --endpoint 127.0.0.1:50051  --wallet-index 9 -yq
+assert_balance 0.0006
+snet treasurer claim 1 2 --endpoint 127.0.0.1:50051  --wallet-index 9 -yq
+assert_balance 0.0008
+
+snet client call 0 0.0001 127.0.0.1:50051 classify {}
+snet client call 0 0.0001 127.0.0.1:50051 classify {}
+snet client call 1 0.0001 127.0.0.1:50051 classify {}
+snet client call 2 0.0001 127.0.0.1:50051 classify {}
+
+# we will start claim of all channels but will not write then to blockchain
+echo n | snet treasurer claim-all --endpoint 127.0.0.1:50051  --wallet-index 9 && exit 1 || echo "fail as expected"
+assert_balance 0.0008
+
+snet client call 1 0.0001 127.0.0.1:50051 classify {}
+snet client call 2 0.0001 127.0.0.1:50051 classify {}
+
+# and now we should claim everything (including pending payments)
+snet treasurer claim-all --endpoint 127.0.0.1:50051  --wallet-index 9 -yq 
+assert_balance 0.0014
+
+kill $DAEMON

--- a/test/functional_tests/simple_daemon/test_simple_daemon.py
+++ b/test/functional_tests/simple_daemon/test_simple_daemon.py
@@ -1,0 +1,137 @@
+from snet_cli.utils import compile_proto, DefaultAttributeObject
+from concurrent import futures
+import time
+import web3
+from snet_cli.mpe_channel_command import MPEChannelCommand
+from snet_cli.config import Config
+
+
+compile_proto("../service_spec1", ".", proto_file = "ExampleService.proto")
+compile_proto("../../../snet_cli/resources/proto/", ".", proto_file = "state_service.proto")
+compile_proto("../../../snet_cli/resources/proto/", ".", proto_file = "control_service.proto")
+
+
+import grpc
+
+import ExampleService_pb2
+import ExampleService_pb2_grpc
+
+import state_service_pb2
+import state_service_pb2_grpc
+
+import control_service_pb2
+import control_service_pb2_grpc
+
+payments_unclaimed   = dict()
+payments_in_progress = dict()
+
+# we use MPEChannelCommand._get_channel_state_from_blockchain to get channel state from blockchain
+# we need it to remove already claimed payments from payments_in_progress
+# remove all payments_in_progress with nonce < blockchain nonce
+def remove_already_claimed_payments():
+    conf   = Config()
+    cc = MPEChannelCommand(conf, DefaultAttributeObject())
+    to_remove = []
+    for channel_id in payments_in_progress:
+        blockchain = cc._get_channel_state_from_blockchain(channel_id)
+        if (blockchain["nonce"] > payments_in_progress[channel_id]["nonce"]):
+            to_remove.append(channel_id)
+    for channel_id in to_remove:
+        print("remove payment for channel %i from payments_in_progress"%channel_id)
+        del payments_in_progress[channel_id]
+
+
+class ExampleService(ExampleService_pb2_grpc.ExampleServiceServicer):    
+    def classify(self, request, context):
+        metadata = dict(context.invocation_metadata())
+        channel_id = int(metadata["snet-payment-channel-id"])
+        nonce      = int(metadata["snet-payment-channel-nonce"])
+        amount     = int(metadata["snet-payment-channel-amount"])
+        signature  = metadata["snet-payment-channel-signature-bin"]        
+        payment = {"channel_id": channel_id, "nonce": nonce, "amount": amount, "signature": signature}
+        payments_unclaimed[channel_id] = payment
+        return ExampleService_pb2.ClassifyResponse(predictions=["prediction1", "prediction2" ], confidences=[0.42, 0.43])
+
+
+class PaymentChannelStateService(state_service_pb2_grpc.PaymentChannelStateServiceServicer):    
+    def GetChannelState(self, request, context):
+        channel_id = int.from_bytes(request.channel_id, byteorder='big')
+        if (channel_id in payments_unclaimed):
+            nonce         = payments_unclaimed[channel_id]["nonce"]
+            amount = payments_unclaimed[channel_id]["amount"]
+            signature     = payments_unclaimed[channel_id]["signature"]
+        else:
+            nonce  = 0
+            amount = 0
+            signature = "".encode("ascii")
+        return state_service_pb2.ChannelStateReply(current_nonce         = web3.Web3.toBytes(nonce), 
+                                                   current_signed_amount = web3.Web3.toBytes(amount), 
+                                                   current_signature     = signature)
+
+
+class ProviderControlService(control_service_pb2_grpc.ProviderControlServiceServicer):    
+    def GetListUnclaimed(self, request, context):        
+        payments = []
+        for channel_id in payments_unclaimed:
+            nonce  = payments_unclaimed[channel_id]["nonce"]
+            amount = payments_unclaimed[channel_id]["amount"]
+            payment = control_service_pb2.PaymentReply(
+                           channel_id    = web3.Web3.toBytes(channel_id),
+                           channel_nonce = web3.Web3.toBytes(nonce),
+                           signed_amount = web3.Web3.toBytes(amount))
+            payments.append(payment)
+        return control_service_pb2.PaymentsListReply(payments = payments)
+
+    def GetListInProgress(self, request, context):        
+        remove_already_claimed_payments()
+
+        payments = []
+        for channel_id in payments_in_progress:
+            p = payments_in_progress[channel_id]
+            payment = control_service_pb2.PaymentReply(
+                           channel_id    = web3.Web3.toBytes(channel_id),
+                           channel_nonce = web3.Web3.toBytes(p["nonce"]),
+                           signed_amount = web3.Web3.toBytes(p["amount"]),
+                           signature     = p["signature"])
+            payments.append(payment)
+        return control_service_pb2.PaymentsListReply(payments = payments)
+
+    def StartClaim(self, request, context):        
+        remove_already_claimed_payments()
+
+        channel_id = int.from_bytes(request.channel_id, byteorder='big')
+        
+        if (channel_id not in payments_unclaimed):
+            raise Exception("channel_id not in payments_unclaimed")
+        
+        p = payments_unclaimed[channel_id]
+        nonce     = p["nonce"]
+        amount    = p["amount"]
+        signature = p["signature"] 
+        payments_in_progress[channel_id] = p
+        payments_unclaimed[channel_id] = {"nonce" : nonce + 1, "amount" : 0, "signature" : bytes(0)}
+        
+        return control_service_pb2.PaymentReply(
+                        channel_id    = web3.Web3.toBytes(channel_id),
+                        channel_nonce = web3.Web3.toBytes(nonce),
+                        signed_amount = web3.Web3.toBytes(amount),
+                        signature     = signature)
+
+
+def serve():
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
+    ExampleService_pb2_grpc.add_ExampleServiceServicer_to_server(ExampleService(), server)
+    state_service_pb2_grpc.add_PaymentChannelStateServiceServicer_to_server(PaymentChannelStateService(), server)
+    control_service_pb2_grpc.add_ProviderControlServiceServicer_to_server(ProviderControlService(), server)
+    server.add_insecure_port('[::]:50051')
+    server.start()
+    try:
+        while True:
+            time.sleep(60*60*24)
+    except KeyboardInterrupt:
+        server.stop(0)
+            
+            
+if __name__ == '__main__':
+    serve()
+                                                                        


### PR DESCRIPTION
This PR add treasurer logic (solves #134). This PR also add 'dummy' daemon for testing of ```snet treasurer``` logic together with previously untested ```snet client call```.

We have the following functions:
- ```snet treasurer print-unclaimed``` - Print all unclaimed payments and total amount of unclaimed funds. 
- ```snet treasurer claim``` - Claim given channels. We also claim all pending 'payments in progress' in case we 'lost' some payments.
-  ```snet treasurer claim-all```  -    Claim all channels. We also claim all 'pending' payments.
-  ```snet treasurer claim-expired``` -  Claim all channels which are close to expiration date. This function have ```--expiration-threshold``` parameter: expiration threshold in blocks (default is 34560 ~ 6 days with 15s/block)

Service provide can simply call ```snet treasurer claim-expired``` with frequency depending on his payment_expiration_threshold defined in metadata. With default value of payment_expiration_threshold=40320 (one week) he could call ```claim-expired``` one time per day (it will be safe enough).
He can call ```snet treasurer claim-all``` when he need it.

There are two features which haven't been implemented in this PR. I will create issues for them.
1. In the current version we can specify only one  endpoint via parameter ```--endpoint```. We should get endpoints from metadata and use round robin.
2. I the current version we use MPE.channelClaim. But we should use MPE.multiChannelClaim in order to save time and gas.
