### PR TITLE
[pyyaml] Update version due to vulnerability.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'ecdsa==0.13',
         'trezor==0.9.1',
         'rlp==0.6.0',
-        'PyYAML==3.12',
+        'pyyaml>=4.2b1',
         'ipfsapi==0.4.2.post1',
         'rfc3986==1.1.0',
         'hidapi>=0.7.99',  # _vendor/ledgerblue


### PR DESCRIPTION
Reference: #163 

I added the `>=` as suggested by GitHub and because I saw that the maintainers of the module are updating it very fast, when a "final" version is released (eg `4.3`) we can analyze it to change back to `==`.