### PR TITLE
Fix 'snet service update-metadata' and add 'snet service metadata-set-model'

### DIFF
--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -624,8 +624,8 @@ def add_mpe_service_options(parser):
 
     p = subparsers.add_parser("update-metadata", help="Publish metadata in IPFS and update existed service")
     p.set_defaults(fn="publish_metadata_in_ipfs_and_update_registration")
+    add_p_publish_params(p)
     add_p_service_in_registry(p)
-    add_p_metadata_file_opt(p)
     add_transaction_arguments(p)
 
     p = subparsers.add_parser("update-add-tags", help="Add tags to existed service registration")

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -582,6 +582,11 @@ def add_mpe_service_options(parser):
     p.add_argument("--endpoints", default=[], nargs='*', help="endpoints for the first group")
     p.add_argument("--fixed-price",type=stragi2cogs, help="set fixed price in AGI token for all methods")
 
+    p = subparsers.add_parser("metadata-set-model", help="publish protobuf model in ipfs and update existed metadata file")
+    p.set_defaults(fn="publish_proto_metadata_update")
+    p.add_argument("protodir",     help="Directory which contains protobuf files")
+    add_p_metadata_file_opt(p)
+
     p = subparsers.add_parser("metadata-set-fixed-price", help="Set pricing model as fixed price for all methods")
     p.set_defaults(fn="metadata_set_fixed_price")
     p.add_argument("price", type = stragi2cogs, help="set fixed price in AGI token for all methods")

--- a/snet_cli/mpe_client_command.py
+++ b/snet_cli/mpe_client_command.py
@@ -1,5 +1,4 @@
 from snet_cli.mpe_channel_command import MPEChannelCommand
-from snet_cli.commands import BlockchainCommand
 from snet_cli.utils import compile_proto
 import base64
 from pathlib import Path
@@ -9,10 +8,7 @@ import os
 import grpc
 from eth_account.messages import defunct_hash_message
 from snet_cli.utils_proto import import_protobuf_from_dir, switch_to_json_payload_econding
-from snet_cli.utils import type_converter
 from snet_cli.mpe_service_metadata import load_mpe_service_metadata
-import shutil
-import tempfile
 from snet_cli.utils_agi2cogs import cogs2stragi
 
 

--- a/snet_cli/mpe_service_command.py
+++ b/snet_cli/mpe_service_command.py
@@ -30,6 +30,13 @@ class MPEServiceCommand(BlockchainCommand):
             metadata.set_fixed_price_in_cogs(self.args.fixed_price)
         metadata.save_pretty(self.args.metadata_file)
 
+    # publish protobuf model in ipfs and update existed metadata file
+    def publish_proto_metadata_update(self):
+        metadata = load_mpe_service_metadata(self.args.metadata_file)
+        ipfs_hash_base58 = utils_ipfs.publish_proto_in_ipfs(self._get_ipfs_client(), self.args.protodir)
+        metadata.set_simple_field("model_ipfs_hash", ipfs_hash_base58)
+        metadata.save_pretty(self.args.metadata_file)
+
     def metadata_set_fixed_price(self):
         metadata = load_mpe_service_metadata(self.args.metadata_file)
         metadata.set_fixed_price_in_cogs(self.args.price)

--- a/snet_cli/mpe_treasurer_command.py
+++ b/snet_cli/mpe_treasurer_command.py
@@ -1,10 +1,7 @@
 from snet_cli.mpe_channel_command import MPEChannelCommand
 from snet_cli.utils import compile_proto
 from pathlib import Path
-import sys
-import os
 import grpc
-from eth_account.messages import defunct_hash_message
 from snet_cli.utils_proto import import_protobuf_from_dir
 from snet_cli.utils import int4bytes_big
 from snet_cli.utils_agi2cogs import cogs2stragi

--- a/snet_cli/utils.py
+++ b/snet_cli/utils.py
@@ -1,4 +1,3 @@
-import _md5
 import json
 import os
 from pathlib import Path

--- a/test/functional_tests/script1_twogroups.sh
+++ b/test/functional_tests/script1_twogroups.sh
@@ -8,6 +8,9 @@ snet service metadata-init ./ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E3
 
 # happy flow
 snet service metadata-init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --encoding json --service-type jsonrpc --group-name group1
+jq .model_ipfs_hash=1 service_metadata.json > tmp.txt
+mv -f tmp.txt service_metadata.json
+snet service metadata-set-model ./service_spec1/
 snet service metadata-add-description --json '{"description_string":"string1","description_int":1,"description_dict":{"a":1,"b":"s"}}'
 snet service metadata-add-description --json '{"description_string":"string1","description_int":1,"description_dict":{"a":1,"b":"s"}}' --description "description" --url "http://127.0.0.1"
 cat service_metadata.json | jq '.service_description.url' |grep "http://127.0.0.1"

--- a/test/functional_tests/script1_twogroups.sh
+++ b/test/functional_tests/script1_twogroups.sh
@@ -159,3 +159,8 @@ snet service publish testo tests4 --multipartyescrow-at 0x52653A9091b5d5021bed06
 snet service publish testo tests5 -yq && exit 1 || echo "fail as expected"
 snet service publish testo tests6 --update-mpe-address -yq
 snet service publish testo tests7 -yq
+
+# test snet service update-metadata
+snet service metadata-add-group group2 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18
+snet service metadata-add-endpoints 8.8.8.8:22  1.2.3.4:8080 --group-name group2
+snet service update-metadata testo tests7 -y


### PR DESCRIPTION
This PR does following:

- Fix a bug in ```snet service update-metadata```
- Add function for update protobuf model of the service in metadata (fix #166).
- Add tests for ```snet service update-metadata``` and ```snet service metadata-set-model```

If service provider need to update protobuf model he can do the following:
```
# Get current service metadata
snet service  print-metadata  <org_id> <service_id> >  service_metadata.json

# Update protobuf model in ipfs and update service metadata file 
snet service metadata-set-model <new_protobuf_dir>

# Update metadata in the registry 
snet service update-metadata
```