### PR TITLE
Add  '--save-response' and '--save-field' for 'snet client call*' commands

### DIFF
--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -1,4 +1,3 @@
-
 import argparse
 import os
 import re

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -1,3 +1,4 @@
+
 import argparse
 import os
 import re
@@ -541,6 +542,11 @@ def add_mpe_client_options(parser):
     subparsers = parser.add_subparsers(title="Commands", metavar="COMMAND")
     subparsers.required = True
 
+    def add_p_deal_with_response(p):
+        p.add_argument("--save-response", default=None, help="save response in the file", metavar="FILENAME")
+        p.add_argument("--save-field",    default=None, nargs=2, help="save specific field in the file (two arguments 'field' and 'file_name' should be specified)")
+
+
     p = subparsers.add_parser("call", help="call server in stateless manner. We ask state of the channel from the server. Channel should be already initialized.")
     p.set_defaults(fn="call_server_statelessly")
     add_p_channel_id(p)
@@ -548,12 +554,14 @@ def add_mpe_client_options(parser):
     add_p_full_service_for_call(p)
     add_p_mpe_address_opt(p)
     add_eth_call_arguments(p)
+    add_p_deal_with_response(p)
 
     p = subparsers.add_parser("call-lowlevel", help="Low level function for calling the server. Channel should be already initialized.")
     p.set_defaults(fn="call_server_lowlevel")
     add_p_full_message(p)
     add_p_full_service_for_call(p)
     add_eth_call_arguments(p)
+    add_p_deal_with_response(p)
 
     p = subparsers.add_parser("get-channel-state", help="Get channel state in stateless manner")
     p.set_defaults(fn="print_channel_state_statelessly")

--- a/snet_cli/mpe_client_command.py
+++ b/snet_cli/mpe_client_command.py
@@ -115,13 +115,29 @@ class MPEClientCommand(MPEChannelCommand):
             raise Exception("Channel %i is not initilized"%self.args.channel_id)
         return load_mpe_service_metadata(self.get_channel_dir().joinpath("service_metadata.json"))
 
+    def _deal_with_call_response(self, response):
+        if (self.args.save_response):
+            with open(self.args.save_response, "wb") as f:
+                f.write(response.SerializeToString())
+        elif (self.args.save_field):
+            field = getattr(response, self.args.save_field[0])
+            file_name = self.args.save_field[1]
+            if (type(field) == bytes):
+                with open(file_name, "wb") as f:
+                    f.write(field)
+            else:
+                with open(file_name, "w") as f:
+                    f.write(str(field))
+        else:
+            self._printout(response)
+
     def call_server_lowlevel(self):
         params           = self._get_call_params()
         grpc_channel     = grpc.insecure_channel(self.args.endpoint)
         service_metadata = self._get_service_metadata_for_channel()
 
         response = self._call_server_via_grpc_channel(grpc_channel, self.args.nonce, self.args.amount, params, service_metadata)
-        self._printout(response)
+        self._deal_with_call_response(response)
 
     # III. Stateless client related functions
     def _get_channel_state_from_server(self, grpc_channel, channel_id):
@@ -193,5 +209,4 @@ class MPEClientCommand(MPEChannelCommand):
         current_nonce, current_amount, unspent_amount = self._get_channel_state_statelessly(grpc_channel, self.args.channel_id)
         self._printout("unspent_amount_in_cogs before call (None means that we cannot get it now):%s"%str(unspent_amount))
         response = self._call_server_via_grpc_channel(grpc_channel, current_nonce, current_amount + self.args.price, params, service_metadata)
-        self._printout(response)
-
+        self._deal_with_call_response(response)

--- a/test/functional_tests/script9_treasurer.sh
+++ b/test/functional_tests/script9_treasurer.sh
@@ -26,9 +26,10 @@ snet channel open-init-metadata 1 $EXPIRATION1 -yq
 snet channel open-init-metadata 1 $EXPIRATION2 -yq
 
 snet client call 0 0.0001 127.0.0.1:50051 classify {}
-snet client call 0 0.0001 127.0.0.1:50051 classify {}
-snet client call 1 0.0001 127.0.0.1:50051 classify {}
-snet client call 2 0.0001 127.0.0.1:50051 classify {}
+snet client call 0 0.0001 127.0.0.1:50051 classify {} --save-response response.pb
+snet client call 1 0.0001 127.0.0.1:50051 classify {} --save-field binary_field out.bin
+snet client call 2 0.0001 127.0.0.1:50051 classify {} --save-field predictions out.txt
+rm -f response.pb out.bin out.txt
 snet treasurer claim-all --endpoint 127.0.0.1:50051  --wallet-index 9 -yq
 snet treasurer claim-all --endpoint 127.0.0.1:50051  --wallet-index 9 -yq
 assert_balance 0.0004

--- a/test/functional_tests/service_spec1/ExampleService.proto
+++ b/test/functional_tests/service_spec1/ExampleService.proto
@@ -12,5 +12,6 @@ message ClassifyRequest {
 message ClassifyResponse {
   repeated string predictions = 1;  
   repeated float confidences = 2;
+  bytes binary_field = 3;
 }
 

--- a/test/functional_tests/simple_daemon/test_simple_daemon.py
+++ b/test/functional_tests/simple_daemon/test_simple_daemon.py
@@ -50,7 +50,7 @@ class ExampleService(ExampleService_pb2_grpc.ExampleServiceServicer):
         signature  = metadata["snet-payment-channel-signature-bin"]        
         payment = {"channel_id": channel_id, "nonce": nonce, "amount": amount, "signature": signature}
         payments_unclaimed[channel_id] = payment
-        return ExampleService_pb2.ClassifyResponse(predictions=["prediction1", "prediction2" ], confidences=[0.42, 0.43])
+        return ExampleService_pb2.ClassifyResponse(predictions=["prediction1", "prediction2" ], confidences=[0.42, 0.43], binary_field = int(12345**5).to_bytes(10,byteorder='big'))
 
 
 class PaymentChannelStateService(state_service_pb2_grpc.PaymentChannelStateServiceServicer):    


### PR DESCRIPTION
fix https://github.com/singnet/snet-cli/issues/185

This PR add two optional parameters for ```snet client call``` and ```snet client call-lowlevel```:
1. ```--save-response <file_name>``` which save response as serialized protobuf in the given file
2. ```--save-field <field> <file_name>``` which save specific field in the given file. If field is binary field is saved as it is in the binary file. In all other cases field is converted to string ```str(field)```