### PR TITLE
Set expiration in days or relative blocks

### DIFF
--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -414,9 +414,17 @@ def add_p_full_message(p):
 def add_p_group_name(p):
     p.add_argument("--group-name", default=None, help="name of the payment group. Parameter should be specified only for services with several payment groups")
 
+def add_p_expiration(p, is_optional):
+    h = "expiration time in blocks (<int>), or in blocks related to the current_block (+<int>blocks), or in days related to the current_block and assuming 15 sec/block (+<int>days)"
+    if (is_optional):
+        p.add_argument("--expiration", required=True,  help=h)
+    else:
+        p.add_argument("expiration",  help=h)
+    p.add_argument("--force", action="store_true", help="Skip check for very high (>6 month) expiration time")
+
 def add_p_open_channel_basic(p):
     p.add_argument("amount",         type=stragi2cogs, help="amount of AGI tokens to put in the new channel")
-    p.add_argument("expiration",     type=int, help="expiration time (in blocks) for the new channel (one block ~ 15 seconds)")
+    add_p_expiration(p, is_optional = False)
     p.add_argument("--signer", default=None, help="Signer for the channel (by default is equal to the sender)")
     add_p_group_name(p)
     add_p_mpe_address_opt(p)
@@ -461,7 +469,7 @@ def add_mpe_channel_options(parser):
     p.set_defaults(fn="channel_extend_and_add_funds")
     add_p_channel_id(p)
     expiration_amount_g = p.add_argument_group(title="Expiration and amount")
-    expiration_amount_g.add_argument("--expiration", type=int,         required=True, help="New expiration for the channel (should be bigger then old one)")
+    add_p_expiration(expiration_amount_g, is_optional = True)
     expiration_amount_g.add_argument("--amount",     type=stragi2cogs, required=True, help="Amount of AGI tokens to add to the channel")
     add_p_mpe_address_opt(p)
     add_transaction_arguments(p)

--- a/snet_cli/mpe_channel_command.py
+++ b/snet_cli/mpe_channel_command.py
@@ -104,7 +104,7 @@ class MPEChannelCommand(MPEServiceCommand):
         We allow the following types of expirations
          1. "<int>" simple integer defines absolute expiration in blocks
          2. "+<int>blocks", where <int> is integer sets expiration as: current_block + <int>
-         3. "+<int>days", where <int> is integer sets expiration as: current_block + N*4*60*24 (we assume 15 sec/block here)
+         3. "+<int>days", where <int> is integer sets expiration as: current_block + <int>*4*60*24 (we assume 15 sec/block here)
 
         If expiration > current_block + 1036800 (~6 month) we generate an exception if "--force" flag haven't been set
         """

--- a/snet_cli/mpe_channel_command.py
+++ b/snet_cli/mpe_channel_command.py
@@ -98,6 +98,30 @@ class MPEChannelCommand(MPEServiceCommand):
         metadata      = self._get_service_metadata_from_registry()
         self._try_init_channel_from_metadata(metadata)
 
+    def _get_expiration_from_args(self):
+        """
+        read expiration from args.
+        We allow the following types of expirations
+         1. "<int>" simple integer defines absolute expiration in blocks
+         2. "+<int>blocks", where <int> is integer sets expiration as: current_block + <int>
+         3. "+<int>days", where <int> is integer sets expiration as: current_block + N*4*60*24 (we assume 15 sec/block here)
+
+        If expiration > current_block + 1036800 (~6 month) we generate an exception if "--force" flag haven't been set
+        """
+        current_block = self.ident.w3.eth.blockNumber
+        s = self.args.expiration
+        if (s.startswith("+") and s.endswith("days")):
+            rez = current_block + int(s[1:-4]) * 4 * 60 * 24
+        elif (s.startswith("+") and s.endswith("blocks")):
+            rez = current_block + int(s[1:-6])
+        else:
+            rez = int(s)
+        if (rez > current_block + 1036800 and not self.args.force):
+            d = (rez - current_block) // (4 * 60 * 24)
+            raise Exception("You try to set expiration time too far in the future: approximately %i days. "%d +
+                            "Set --force parameter if your really want to do it.")
+        return rez
+
     def _open_channel_for_service(self, metadata):
         group_id    = metadata.get_group_id(self.args.group_name)
         recipient   = metadata.get_payment_address(self.args.group_name)
@@ -108,7 +132,8 @@ class MPEChannelCommand(MPEServiceCommand):
             signer = self.ident.address
 
         channel_info = {"sender": self.ident.address, "signer": signer, "recipient": recipient, "groupId" : group_id}
-        params = [channel_info["signer"], channel_info["recipient"], channel_info["groupId"], self.args.amount, self.args.expiration]
+        expiration = self._get_expiration_from_args()
+        params = [channel_info["signer"], channel_info["recipient"], channel_info["groupId"], self.args.amount, expiration]
         rez = self.transact_contract_command("MultiPartyEscrow", "openChannel", params)
 
         if (len(rez[1]) != 1 or rez[1][0]["event"] != "ChannelOpen"):
@@ -145,7 +170,8 @@ class MPEChannelCommand(MPEServiceCommand):
         self.transact_contract_command("MultiPartyEscrow", "channelClaimTimeout", [self.args.channel_id])
 
     def channel_extend_and_add_funds(self):
-        self.transact_contract_command("MultiPartyEscrow", "channelExtendAndAddFunds", [self.args.channel_id, self.args.expiration, self.args.amount])
+        expiration = self._get_expiration_from_args()
+        self.transact_contract_command("MultiPartyEscrow", "channelExtendAndAddFunds", [self.args.channel_id, expiration, self.args.amount])
 
     def _get_all_initilized_channels(self):
         """ return list of tuples (channel_id, channel_info) """

--- a/test/functional_tests/script1_twogroups.sh
+++ b/test/functional_tests/script1_twogroups.sh
@@ -73,8 +73,16 @@ snet channel claim-timeout 0 -y -q
 # we do not send transaction second time
 snet channel claim-timeout 0 -y -q && exit 1 || echo "fail as expected"
 
-snet channel extend-add 0 --expiration 10000 --amount 42 -y  -q
-snet channel open-init  testo tests 1 1000000  --group-name group2 -y -q
+snet channel extend-add 0 --expiration 10000         --amount 42 -y  -q
+snet channel extend-add 0 --expiration +10000blocks  --amount 0  -y  -q
+snet channel extend-add 0 --expiration +10000days    --amount 0  -y  -q && exit 1 || echo "fail as expected"
+snet channel extend-add 0 --expiration +10000days --force  --amount 0  -y  -q
+snet channel extend-add 0 --expiration 57600000 --force  --amount 0  -y  -q && exit 1 || echo "fail as expected"
+
+EXPIRATION1=$((`snet channel block-number` + 57600000))
+snet channel extend-add 0 --expiration $EXPIRATION1 --force  --amount 0  -y  -q
+
+snet channel open-init  testo tests 1 +14days  --group-name group2 -y -q
 
 # test print_initialized_channels and print_all_channels. We should have channels openned for specific identity
 snet channel print-initialized | grep 0x42A605c07EdE0E1f648aB054775D6D4E38496144
@@ -131,7 +139,7 @@ snet organization list-services testo
 # open channel with sender=signer=0x32267d505B1901236508DcDa64C1D0d5B9DF639a
 
 snet account transfer 0x32267d505B1901236508DcDa64C1D0d5B9DF639a 1 -y -q
-snet channel open-init testo tests2 1 314156700003452 -y  -q --wallet-index 3
+snet channel open-init testo tests2 1 314156700003452 --force -y  -q --wallet-index 3
 snet channel print-all-filter-sender --sender 0x32267d505B1901236508DcDa64C1D0d5B9DF639a |grep 314156700003452
 snet channel print-all-filter-sender |grep 314156700003452 && exit 1 || echo "fail as expected"
 


### PR DESCRIPTION
fix #189 
This PR add possibility to set expiration in days or in blocks relative to the current_block in ```snet channel open-init``` and in ```snet channel extend-add```

We allow the following types of expiration
1. ```<int>``` simple integer defines absolute expiration in blocks
2. ```+<int>blocks```, where ```<int>``` is an integer sets expiration as: ```current_block + <int>```
3. ```+<int>days```, where ```<int>``` is integer sets expiration as: ```current_block + <int>*4*60*24``` (we assume 15 sec/block here)

We also raise an exception if expiration time is more than 6 month in the future (1036800). However you can skip this check by ```--force```.

For example:
```
# old style. open channel with expiration time 1000 blocks (in absolute values) 
snet channel open-init  testo tests 1 1000  -y -q

# set expiration time for channel 0 as current_block + 10000
snet channel extend-add 0 --expiration +10000blocks  --amount 0  -y  -q

# open channel with expiration time current_block + 14 * 4 * 60 * 24 (14 days in the future)
snet channel open-init  testo tests 1 +14days  -y -q

# this will raise an exception, because expiration time is too far in the future
snet channel open-init  testo tests 1 100000000000  -y -q
```
