### PR TITLE
Client library generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ snet_cli/resources/contracts/networks
 snet_cli/resources/proto/*.py
 build/
 dist/
-
+client_libraries/

--- a/README.md
+++ b/README.md
@@ -378,6 +378,20 @@ snet organization rem-members [-h] [--gas-price GAS_PRICE]
 
 ---
 
+```
+snet sdk generate-client-library [-h] [--eth-rpc-endpoint ETH_RPC_ENDPOINT]
+                                      [--registry-at REGISTRY_ADDRESS]
+                                      language organization service [protodir] 
+```
+
+* Generate compiled client libraries to call services using your language of choice
+  * `language`: target client library language
+  * `organization`: id of the organization
+  * `service`: id of the service
+  * `protodir`: directory where to output the generated client libraries
+
+---
+
 ## Development
 
 ### Installing

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     description='SingularityNET CLI',
     python_requires='>=3.6',
     install_requires=[
-        'grpcio-tools==1.14.1',
+        'grpcio-tools==1.17.1',
         'jsonrpcclient==2.5.2',
         'web3==4.2.1',
         'mnemonic==0.18',

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -12,6 +12,7 @@ from snet_cli.mpe_service_command import MPEServiceCommand
 from snet_cli.mpe_channel_command import MPEChannelCommand
 from snet_cli.mpe_client_command  import MPEClientCommand
 from snet_cli.mpe_treasurer_command import MPETreasurerCommand
+from snet_cli.sdk_command import SDKCommand
 from snet_cli.utils_agi2cogs import stragi2cogs
 from snet_cli.config import get_session_keys, get_session_network_keys_removable
 
@@ -89,6 +90,9 @@ def add_root_options(parser, config):
 
     p = subparsers.add_parser("treasurer", help="Treasurer logic")
     add_mpe_treasurer_options(p)
+
+    sdk_p = subparsers.add_parser("sdk", help="Generate client libraries to call SingularityNET services using your language of choice")
+    add_sdk_options(sdk_p)
 
 
 def add_version_options(parser):
@@ -606,7 +610,7 @@ def add_mpe_client_options(parser):
     add_p_channel_id(p)
     add_p_endpoint(p)
     add_eth_call_arguments(p)
-
+ 
 
 def add_mpe_service_options(parser):
     parser.set_defaults(cmd=MPEServiceCommand)
@@ -747,3 +751,20 @@ def add_mpe_treasurer_options(parser):
     p.add_argument("--expiration-threshold", type=int, default = 34560, help="Service expiration threshold in blocks (default is 34560 ~ 6 days with 15s/block)")
     add_p_endpoint(p)
     add_transaction_arguments(p)
+
+def add_sdk_options(parser):
+    parser.set_defaults(cmd=SDKCommand)
+    subparsers = parser.add_subparsers(title="Commands", metavar="COMMAND")
+    subparsers.required = True
+
+    supported_languages = [ "python" ]
+
+    p = subparsers.add_parser("generate-client-library", help="Generate compiled client libraries to call services using your language of choice")
+    p.set_defaults(fn="generate_client_library")
+    p.add_argument("language", choices=supported_languages,
+                   help="choose target language for the generated client library from {}".format(supported_languages),
+                   metavar="LANGUAGE")
+    p.add_argument("org_id", help="Id of the target service organization in the SingularityNET Registry", metavar="ORGANIZATION_ID")
+    p.add_argument("service_id", help="Id of the target service in the SingularityNET Registry", metavar="SERVICE_ID")
+    p.add_argument("protodir", nargs="?", help="Directory where to output the generated client libraries", metavar="PROTODIR")
+    add_eth_call_arguments(p)

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -764,7 +764,6 @@ def add_sdk_options(parser):
     p.add_argument("language", choices=supported_languages,
                    help="choose target language for the generated client library from {}".format(supported_languages),
                    metavar="LANGUAGE")
-    p.add_argument("org_id", help="Id of the target service organization in the SingularityNET Registry", metavar="ORGANIZATION_ID")
-    p.add_argument("service_id", help="Id of the target service in the SingularityNET Registry", metavar="SERVICE_ID")
+    add_p_service_in_registry(p)
     p.add_argument("protodir", nargs="?", help="Directory where to output the generated client libraries", metavar="PROTODIR")
     add_eth_call_arguments(p)

--- a/snet_cli/sdk_command.py
+++ b/snet_cli/sdk_command.py
@@ -1,0 +1,59 @@
+from snet_cli.commands import BlockchainCommand
+import os 
+from pathlib import Path, PurePath
+from tempfile import TemporaryDirectory
+
+from snet_cli.utils import type_converter, bytes32_to_str, compile_proto
+from snet_cli.utils_ipfs import bytesuri_to_hash, get_from_ipfs_and_checkhash, safe_extract_proto_from_ipfs
+from snet_cli.mpe_service_metadata import mpe_service_metadata_from_json
+
+class SDKCommand(BlockchainCommand):
+    def generate_client_library(self):
+        cur_dir_path = PurePath(os.path.dirname(os.path.realpath(__file__)))
+
+        if not self.args.protodir:
+            client_libraries_base_dir_path = cur_dir_path.parent.joinpath("client_libraries")
+            if not os.path.exists(client_libraries_base_dir_path):
+                os.makedirs(client_libraries_base_dir_path)
+        else:
+            if os.path.isabs(self.args.protodir):
+                client_libraries_base_dir_path = PurePath(self.args.protodir)
+            else: 
+                client_libraries_base_dir_path = PurePath(os.getcwd()).joinpath(self.args.protodir)
+
+            if not os.path.isdir(client_libraries_base_dir_path):
+                self._error("directory {} does not exist. Please make sure that the specified path exists".format(client_libraries_base_dir_path))
+
+        # Check that service exists
+        (found, org_service_list) = self.call_contract_command("Registry", "listServicesForOrganization", [type_converter("bytes32")(self.args.org_id)])
+        if not found:
+            self._error("organization {} does not exist".format(self.args.org_id))
+
+        org_service_list = list(map(bytes32_to_str, org_service_list))
+
+        if self.args.service_id not in org_service_list:
+            self._error("service {} does not exist in organization {}".format(self.args.service_id, self.args.org_id))
+
+        # Create service client libraries path
+        library_language = self.args.language
+        library_org_id = self.args.org_id
+        library_service_id = self.args.service_id
+
+        library_dir_path = client_libraries_base_dir_path.joinpath(library_language, library_org_id, library_service_id)
+
+        # Download and extract proto files
+        ipfs_metadata_hash = bytesuri_to_hash(self.call_contract_command("Registry", "getServiceRegistrationById", [type_converter("bytes32")(self.args.org_id), type_converter("bytes32")(self.args.service_id)])[2])
+        metadata = get_from_ipfs_and_checkhash(self._get_ipfs_client(), ipfs_metadata_hash)
+        metadata = metadata.decode("utf-8")
+        metadata = mpe_service_metadata_from_json(metadata)
+        model_ipfs_hash = metadata["model_ipfs_hash"]
+
+        with TemporaryDirectory() as temp_dir: 
+            temp_dir_path = PurePath(temp_dir)
+            proto_temp_dir_path = temp_dir_path.joinpath(library_language, library_org_id, library_service_id)
+            safe_extract_proto_from_ipfs(self._get_ipfs_client(), model_ipfs_hash, proto_temp_dir_path)
+
+        # Compile proto files
+            compile_proto(Path(proto_temp_dir_path), library_dir_path)
+
+        self._printout('client libraries for service with id "{}" in org with id "{}" generated at {}'.format(library_service_id, library_org_id, library_dir_path))

--- a/snet_cli/sdk_command.py
+++ b/snet_cli/sdk_command.py
@@ -9,17 +9,17 @@ from snet_cli.mpe_service_metadata import mpe_service_metadata_from_json
 
 class SDKCommand(MPEServiceCommand):
     def generate_client_library(self):
-        cur_dir_path = PurePath(os.path.dirname(os.path.realpath(__file__)))
+        cur_dir_path = PurePath(os.getcwd())
 
         if not self.args.protodir:
-            client_libraries_base_dir_path = cur_dir_path.parent.joinpath("client_libraries")
+            client_libraries_base_dir_path = cur_dir_path.joinpath("client_libraries")
             if not os.path.exists(client_libraries_base_dir_path):
                 os.makedirs(client_libraries_base_dir_path)
         else:
             if os.path.isabs(self.args.protodir):
                 client_libraries_base_dir_path = PurePath(self.args.protodir)
             else: 
-                client_libraries_base_dir_path = PurePath(os.getcwd()).joinpath(self.args.protodir)
+                client_libraries_base_dir_path = cur_dir_path.joinpath(self.args.protodir)
 
             if not os.path.isdir(client_libraries_base_dir_path):
                 self._error("directory {} does not exist. Please make sure that the specified path exists".format(client_libraries_base_dir_path))

--- a/snet_cli/sdk_command.py
+++ b/snet_cli/sdk_command.py
@@ -1,4 +1,4 @@
-from snet_cli.commands import BlockchainCommand
+from snet_cli.mpe_service_command import MPEServiceCommand
 import os 
 from pathlib import Path, PurePath
 from tempfile import TemporaryDirectory
@@ -7,7 +7,7 @@ from snet_cli.utils import type_converter, bytes32_to_str, compile_proto
 from snet_cli.utils_ipfs import bytesuri_to_hash, get_from_ipfs_and_checkhash, safe_extract_proto_from_ipfs
 from snet_cli.mpe_service_metadata import mpe_service_metadata_from_json
 
-class SDKCommand(BlockchainCommand):
+class SDKCommand(MPEServiceCommand):
     def generate_client_library(self):
         cur_dir_path = PurePath(os.path.dirname(os.path.realpath(__file__)))
 
@@ -24,16 +24,6 @@ class SDKCommand(BlockchainCommand):
             if not os.path.isdir(client_libraries_base_dir_path):
                 self._error("directory {} does not exist. Please make sure that the specified path exists".format(client_libraries_base_dir_path))
 
-        # Check that service exists
-        (found, org_service_list) = self.call_contract_command("Registry", "listServicesForOrganization", [type_converter("bytes32")(self.args.org_id)])
-        if not found:
-            self._error("organization {} does not exist".format(self.args.org_id))
-
-        org_service_list = list(map(bytes32_to_str, org_service_list))
-
-        if self.args.service_id not in org_service_list:
-            self._error("service {} does not exist in organization {}".format(self.args.service_id, self.args.org_id))
-
         # Create service client libraries path
         library_language = self.args.language
         library_org_id = self.args.org_id
@@ -41,11 +31,7 @@ class SDKCommand(BlockchainCommand):
 
         library_dir_path = client_libraries_base_dir_path.joinpath(library_language, library_org_id, library_service_id)
 
-        # Download and extract proto files
-        ipfs_metadata_hash = bytesuri_to_hash(self.call_contract_command("Registry", "getServiceRegistrationById", [type_converter("bytes32")(self.args.org_id), type_converter("bytes32")(self.args.service_id)])[2])
-        metadata = get_from_ipfs_and_checkhash(self._get_ipfs_client(), ipfs_metadata_hash)
-        metadata = metadata.decode("utf-8")
-        metadata = mpe_service_metadata_from_json(metadata)
+        metadata = self._get_service_metadata_from_registry()
         model_ipfs_hash = metadata["model_ipfs_hash"]
 
         with TemporaryDirectory() as temp_dir: 

--- a/snet_cli/sdk_command.py
+++ b/snet_cli/sdk_command.py
@@ -5,6 +5,7 @@ from tempfile import TemporaryDirectory
 
 from snet_cli.utils import type_converter, bytes32_to_str, compile_proto
 from snet_cli.utils_ipfs import bytesuri_to_hash, get_from_ipfs_and_checkhash, safe_extract_proto_from_ipfs
+from snet_cli.utils_config import get_contract_address
 from snet_cli.mpe_service_metadata import mpe_service_metadata_from_json
 
 class SDKCommand(MPEServiceCommand):
@@ -29,7 +30,7 @@ class SDKCommand(MPEServiceCommand):
         library_org_id = self.args.org_id
         library_service_id = self.args.service_id
 
-        library_dir_path = client_libraries_base_dir_path.joinpath(library_language, library_org_id, library_service_id)
+        library_dir_path = client_libraries_base_dir_path.joinpath(library_language, get_contract_address(self, "Registry"), library_org_id, library_service_id)
 
         metadata = self._get_service_metadata_from_registry()
         model_ipfs_hash = metadata["model_ipfs_hash"]


### PR DESCRIPTION
Generate python client libraries to target directory from cli by specifying organization id and service id

Updated grpicio-tools, and pyyaml for Python 3.7 compatibility

Libraries are to be used with snet-python-sdk (PR incoming) to accommodate for import paths in compiled .py grpc files and intercept client calls to add mpe metadata