### PR TITLE
Changes to allow using snet-cli as a library to simulate grpc call

### DIFF
--- a/snet_cli/mpe_client_command.py
+++ b/snet_cli/mpe_client_command.py
@@ -63,7 +63,7 @@ class MPEClientCommand(MPEChannelCommand):
 
         return params
 
-    
+
     def _transform_call_params(self, params):
         """
         possible modifiers: file, b64encode, b64decode
@@ -204,15 +204,17 @@ class MPEClientCommand(MPEChannelCommand):
         if (self.ident.address != channel_info["signer"]):
             raise Exception("You are not the signer of the channel %i"%self.args.channel_id)
 
-    def call_server_statelessly(self):
-        params           = self._get_call_params()
+    def call_server_statelessly_with_params(self, params):
         grpc_channel     = grpc.insecure_channel(remove_http_https_prefix(self.args.endpoint))
         service_metadata = self._get_service_metadata_for_channel()
-
         self._call_check_price(service_metadata)
         self._call_check_signer()
-
         current_nonce, current_amount, unspent_amount = self._get_channel_state_statelessly(grpc_channel, self.args.channel_id)
         self._printout("unspent_amount_in_cogs before call (None means that we cannot get it now):%s"%str(unspent_amount))
         response = self._call_server_via_grpc_channel(grpc_channel, current_nonce, current_amount + self.args.price, params, service_metadata)
+        return response
+
+    def call_server_statelessly(self):
+        params           = self._get_call_params()
+        response = self.call_server_statelessly_with_params(params)
         self._deal_with_call_response(response)

--- a/snet_cli/utils_proto.py
+++ b/snet_cli/utils_proto.py
@@ -8,65 +8,83 @@ from google.protobuf import json_format
 def import_protobuf_from_dir(proto_dir, method_name, service_name = None):
     """
     Dynamic import of grpc-protobuf from given directory (proto_dir)
-    service_name should be provided only in the case of conflicting method names (two methods with the same name in difference services).
+    service_name should be provided only in the case of conflicting method names (two methods with the same name in different services).
     Return stub_class, request_class, response_class
     ! We need response_class only for json payload encoding !
     """
-    proto_dir = Path(proto_dir)
-    # <SERVICE>_pb2_grpc.py import <SERVICE>_pb2.py so we are forced to add proto_dir to path
-    sys.path.append(str(proto_dir))    
-    grpc_pyfiles = [str(os.path.basename(p)) for p in proto_dir.glob("*_pb2_grpc.py")]
-    
-    good_rez = []
-    for grpc_pyfile in grpc_pyfiles:
-        is_found, rez = _import_protobuf_from_file(grpc_pyfile, method_name, service_name);
-        if (is_found): good_rez.append(rez) 
-    if (len(good_rez) == 0):
-        raise Exception("Error while loading protobuf. Cannot find method=%s"%method_name)
-    if (len(good_rez) > 1):
-        if (service_name):
-            raise Exception("Error while loading protobuf. Found method %s.%s in multiply .proto files. We don't support packages yet!"%(service_name, method_name))
-        else:
-            raise Exception("Error while loading protobuf. Found method %s in multiply .proto files. You could try to specify service_name."%method_name)
-    return good_rez[0]
+    all_services =  import_protobuf_from_dir_get_all(proto_dir)
 
-def _import_protobuf_from_file(grpc_pyfile, method_name, service_name = None):
-    """
-    helper function which try to import method from the given _pb2_grpc.py file
-    service_name should be provided only in case of name conflict
-    return (False, None)  in case of failure
-    return (True, (stub_class, request_class, response_class)) in case of success
-    """
-    
-    prefix = grpc_pyfile[:-12]
-    pb2      = __import__("%s_pb2"%prefix)
-    pb2_grpc = __import__("%s_pb2_grpc"%prefix) 
-    
-    
-    # we take all objects from pb2_grpc module which endswith "Stub", and we remove this postfix to get service_name
-    all_service_names = [stub_name[:-4] for stub_name in dir(pb2_grpc) if stub_name.endswith("Stub")]
-    
-    # if service_name was specified we take only this service_name
     if (service_name):
-        if (service_name not in all_service_names):
-            return False, None
-        all_service_names = [service_name]    
-
-    found_services = []
-    for service_name in all_service_names:
-        service_descriptor =  getattr(pb2, "DESCRIPTOR").services_by_name[service_name]
-        for method in service_descriptor.methods:
-            if(method.name == method_name):
-                request_class      = getattr(pb2, method.input_type.name)
-                response_class     = getattr(pb2, method.output_type.name)
-                stub_class         = getattr(pb2_grpc, "%sStub"%service_name)
-                found_services.append(service_name)
+        if (service_name not in all_services):
+            raise Exception("Error while loading protobuf. Cannot find service=%s"%service_name)
+        if (method_name not in all_services[service_name]):
+            raise Exception("Error while loading protobuf. Cannot find method=%s in service=%s"%(method_name,service_name))
+        return all_services[service_name][method_name]
+    found_services = [n for n in all_services if method_name in all_services[n]]
     if (len(found_services) == 0):
-        return False, None
+        raise Exception("Error while loading protobuf. Cannot find method=%s"%method_name)
     if (len(found_services) > 1):
         raise Exception("Error while loading protobuf. We found methods %s in multiply services [%s]."
                         " You should specify service_name."%(method_name, ", ".join(found_services)))
-    return True, (stub_class, request_class, response_class)
+
+    return all_services[found_services[0][method_name]]
+
+
+def import_protobuf_from_dir_get_all(proto_dir):
+    """
+    Helper function which dynamically import of grpc-protobuf from given directory (proto_dir)
+    we return nested dictionary of all methods in all services
+    return all_services[service_name][method_name] = (stub_class, request_class, response_class)
+    """
+
+    proto_dir = Path(proto_dir)
+    # <SERVICE>_pb2_grpc.py import <SERVICE>_pb2.py so we are forced to add proto_dir to path
+    sys.path.append(str(proto_dir))
+    grpc_pyfiles = [str(os.path.basename(p)) for p in proto_dir.glob("*_pb2_grpc.py")]
+
+    all_services = {}
+    for grpc_pyfile in grpc_pyfiles:
+        services = _import_protobuf_from_file_get_all(grpc_pyfile)
+
+        for service_name in services:
+            if (service_name in all_services):
+
+                # check for possible conflict
+                for method_name in services[service_name]:
+                    if (method_name in all_services[service_name]):
+                        raise Exception("Error while loading protobuf. Found method %s.%s in multiply .proto files. We don't support packages yet!"%(service_name, method_name))
+                    all_services[service_name][method_name] = services[service_name][method_name]
+            else:
+                all_services[service_name] = services[service_name]
+    return all_services
+
+
+def _import_protobuf_from_file_get_all(grpc_pyfile):
+    """
+    Helper function which dynamically import services from the given _pb2_grpc.py file
+    we return nested dictionary of all methods in all services
+    return all_services[service_name][method_name] = (stub_class, request_class, response_class)
+    """
+
+    prefix = grpc_pyfile[:-12]
+    pb2      = __import__("%s_pb2"%prefix)
+    pb2_grpc = __import__("%s_pb2_grpc"%prefix)
+
+
+    # we take all objects from pb2_grpc module which endswith "Stub", and we remove this postfix to get service_name
+    all_service_names = [stub_name[:-4] for stub_name in dir(pb2_grpc) if stub_name.endswith("Stub")]
+
+    rez = { s:{} for s in all_service_names}
+
+    for service_name in all_service_names:
+        service_descriptor =  getattr(pb2, "DESCRIPTOR").services_by_name[service_name]
+        for method in service_descriptor.methods:
+            request_class      = getattr(pb2, method.input_type.name)
+            response_class     = getattr(pb2, method.output_type.name)
+            stub_class         = getattr(pb2_grpc, "%sStub"%service_name)
+            rez[service_name][method.name] = (stub_class, request_class, response_class)
+    return rez
+
 
 def switch_to_json_payload_econding(call_fn, response_class):
     """ Switch payload encoding to JSON for GRPC call """

--- a/snet_cli/utils_proto.py
+++ b/snet_cli/utils_proto.py
@@ -27,7 +27,7 @@ def import_protobuf_from_dir(proto_dir, method_name, service_name = None):
         raise Exception("Error while loading protobuf. We found methods %s in multiply services [%s]."
                         " You should specify service_name."%(method_name, ", ".join(found_services)))
 
-    return all_services[found_services[0][method_name]]
+    return all_services[found_services[0]][method_name]
 
 
 def import_protobuf_from_dir_get_all(proto_dir):


### PR DESCRIPTION
This PR is only for discussion.

Changes which allow using snet-cli as a pseudo sdk in: https://github.com/astroseger/simple_snet_sdk

* add ```MPEClientCommand.call_server_statelessly_with_params```
* rewrite ```utils_proto.py``` in order to isolate ```import_protobuf_from_dir_get_all``` which we need to simulate GRPC in pseudo sdk.

It should be noted that the last change (modification of ```utils_proto.py```) is optional because  it can be done in ```https://github.com/astroseger/simple_snet_sdk```
 