### PR TITLE
[fix] Remove http(s) from print_channel_state_statelessly() too

### DIFF
--- a/snet_cli/mpe_client_command.py
+++ b/snet_cli/mpe_client_command.py
@@ -191,7 +191,7 @@ class MPEClientCommand(MPEChannelCommand):
         return (server["current_nonce"], server["current_signed_amount"], unspent_amount)
 
     def print_channel_state_statelessly(self):
-        grpc_channel = grpc.insecure_channel(self.args.endpoint)
+        grpc_channel = grpc.insecure_channel(remove_http_https_prefix(self.args.endpoint))
         current_nonce, current_amount, unspent_amount = self._get_channel_state_statelessly(grpc_channel, self.args.channel_id)
         self._printout("current_nonce                  = %i"%current_nonce)
         self._printout("current_signed_amount_in_cogs  = %i"%current_amount)


### PR DESCRIPTION
```
$ snet client get-channel-state 753 http://54.203.198.53:7092
Error: <_Rendezvous of RPC that terminated with:
	status = StatusCode.UNAVAILABLE
	details = "Name resolution failure"
	debug_error_string = "{"created":"@1550137817.553841627","description":"Failed to create subchannel","file":"src/core/ext/filters/client_channel/client_channel.cc","file_line":2721,"referenced_errors":[{"created":"@1550137817.553836272","description":"Name resolution failure","file":"src/core/ext/filters/client_channel/client_channel.cc","file_line":3026,"grpc_status":14}]}"
>
If you want to see full Traceback then run:
snet --print-traceback [parameters]
```

After this minor fix:

```
$ snet client get-channel-state 753 http://54.203.198.53:7092
current_nonce                  = 0
current_signed_amount_in_cogs  = 0
current_unspent_amount_in_cogs = 1
```