### PR TITLE
Hide channel id and endpoint from user and support https

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     author='SingularityNET Foundation',
     author_email='info@singularitynet.io',
     description='SingularityNET CLI',
+    python_requires='>=3.6',
     install_requires=[
         'grpcio-tools==1.14.1',
         'jsonrpcclient==2.5.2',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ def install_and_compile_proto():
     import snet_cli
     from snet_cli.utils import compile_proto as compile_proto
     from pathlib import Path
-    import glob
     proto_dir = Path(__file__).absolute().parent.joinpath("snet_cli", "resources", "proto")
     dest_dir = Path(snet_cli.__file__).absolute().parent.joinpath("resources", "proto")
     print(proto_dir, "->", dest_dir)

--- a/snet_cli/__init__.py
+++ b/snet_cli/__init__.py
@@ -3,7 +3,7 @@ import sys
 from snet_cli import arguments
 from snet_cli.config import Config
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"
 
 
 def main():

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -569,6 +569,7 @@ def add_mpe_client_options(parser):
     add_p_org_id_service_id(p)
     add_p_set1_for_call(p)
     p.add_argument("--channel-id", type=int, help="channel_id (only in case of multiply initilized channels for the same payment group)")
+    p.add_argument("--yes", "-y", action="store_true", help="skip interactive confirmation of call price", default=False)
 
 
     p = subparsers.add_parser("call-lowlevel", help="Low level function for calling the server. Service should be already initilized.")

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -487,7 +487,7 @@ def add_mpe_channel_options(parser):
     add_p_channel_id(p)
     add_p_set_for_extend_add(p)
 
-    p = subparsers.add_parser("extend-add-for-service", help="Set new expiration for the channel which was initilized for the given service")
+    p = subparsers.add_parser("extend-add-for-service", help="Set new expiration and add funds for the channel which was initilized for the given service")
     p.set_defaults(fn="channel_extend_and_add_funds_for_service")
     add_p_service_in_registry(p)
     add_p_set_for_extend_add(p)

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -663,6 +663,7 @@ def add_mpe_service_options(parser):
     add_p_publish_params(p)
     add_p_service_in_registry(p)
     add_transaction_arguments(p)
+    p.add_argument("--force", action="store_true", help="Force update metadata")
 
     p = subparsers.add_parser("update-add-tags", help="Add tags to existed service registration")
     p.set_defaults(fn="update_registration_add_tags")

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -475,14 +475,22 @@ def add_mpe_channel_options(parser):
     add_transaction_arguments(p)
     add_p_from_block(p)
 
+    def add_p_set_for_extend_add(p):
+        expiration_amount_g = p.add_argument_group(title="Expiration and amount")
+        add_p_expiration(expiration_amount_g, is_optional = True)
+        expiration_amount_g.add_argument("--amount",     type=stragi2cogs, required=True, help="Amount of AGI tokens to add to the channel")
+        add_p_mpe_address_opt(p)
+        add_transaction_arguments(p)
+
     p = subparsers.add_parser("extend-add", help="Set new expiration for the channel and add funds")
     p.set_defaults(fn="channel_extend_and_add_funds")
     add_p_channel_id(p)
-    expiration_amount_g = p.add_argument_group(title="Expiration and amount")
-    add_p_expiration(expiration_amount_g, is_optional = True)
-    expiration_amount_g.add_argument("--amount",     type=stragi2cogs, required=True, help="Amount of AGI tokens to add to the channel")
-    add_p_mpe_address_opt(p)
-    add_transaction_arguments(p)
+    add_p_set_for_extend_add(p)
+
+    p = subparsers.add_parser("extend-add-for-service", help="Set new expiration for the channel which was initilized for the given service")
+    p.set_defaults(fn="channel_extend_and_add_funds_for_service")
+    add_p_service_in_registry(p)
+    add_p_set_for_extend_add(p)
 
     p = subparsers.add_parser("block-number", help="Print the last ethereum block number")
     p.set_defaults(fn="print_block_number")

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -469,6 +469,12 @@ def add_mpe_channel_options(parser):
     add_p_mpe_address_opt(p)
     add_transaction_arguments(p)
 
+    p = subparsers.add_parser("claim-timeout-all", help="Claim timeout for all channels which have current identity as a sender.")
+    p.set_defaults(fn="channel_claim_timeout_all")
+    add_p_mpe_address_opt(p)
+    add_transaction_arguments(p)
+    add_p_from_block(p)
+
     p = subparsers.add_parser("extend-add", help="Set new expiration for the channel and add funds")
     p.set_defaults(fn="channel_extend_and_add_funds")
     add_p_channel_id(p)

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -348,11 +348,13 @@ def add_p_mpe_address_opt(p):
 def add_p_metadata_file_opt(p):
     p.add_argument("--metadata-file", default="service_metadata.json", help="Service metadata json file (default service_metadata.json)")
 
-
-def add_p_service_in_registry(p):
-    p.add_argument("--registry-at", "--registry", default=None, help="address of Registry contract, if not specified we read address from \"networks\"")
+def add_p_org_id_service_id(p):
     add_p_org_id(p)
     p.add_argument("service_id",      help="Id of service")
+
+def add_p_service_in_registry(p):
+    add_p_org_id_service_id(p)
+    p.add_argument("--registry-at", "--registry", default=None, help="address of Registry contract, if not specified we read address from \"networks\"")
 
 
 def add_mpe_account_options(parser):
@@ -430,7 +432,11 @@ def add_p_open_channel_basic(p):
     add_p_group_name(p)
     add_p_mpe_address_opt(p)
     add_transaction_arguments(p)
+    p.add_argument("--open-new-anyway", action="store_true", help="skip check that channel already exists and open new channel anyway")
+    add_p_from_block(p)
 
+def add_p_from_block(p):
+        p.add_argument("--from-block", type=int, default=0, help="Start searching from this block")
 
 def add_mpe_channel_options(parser):
     parser.set_defaults(cmd=MPEChannelCommand)
@@ -445,6 +451,7 @@ def add_mpe_channel_options(parser):
 
     p = subparsers.add_parser("init-metadata", help="Initialize channel using service metadata")
     p.set_defaults(fn="init_channel_from_metadata")
+    add_p_org_id_service_id(p)
     add_p_metadata_file_opt(p)
     add_p_mpe_address_opt(p)
     add_p_channel_id(p)
@@ -455,8 +462,10 @@ def add_mpe_channel_options(parser):
     add_p_service_in_registry(p)
     add_p_open_channel_basic(p)
 
+
     p = subparsers.add_parser("open-init-metadata", help="Open and initilize channel using service metadata")
     p.set_defaults(fn="open_init_channel_from_metadata")
+    add_p_org_id_service_id(p)
     add_p_open_channel_basic(p)
     add_p_metadata_file_opt(p)
 
@@ -494,17 +503,13 @@ def add_mpe_channel_options(parser):
     add_p_mpe_address_opt(p)
     add_eth_call_arguments(p)
 
-    p = subparsers.add_parser("print-initialized-filter-group", help="Print initialized channels for the given service (given payment group).")
-    p.set_defaults(fn="print_initialized_channels_filter_group")
+    p = subparsers.add_parser("print-initialized-filter-service", help="Print initialized channels for the given service (all payment group).")
+    p.set_defaults(fn="print_initialized_channels_filter_service")
     add_p_service_in_registry(p)
     add_p_only_id(p)
     add_p_only_sender_signer(p)
     add_p_mpe_address_opt(p)
     add_eth_call_arguments(p)
-    add_p_group_name(p)
-
-    def add_p_from_block(p):
-        p.add_argument("--from-block", type=int, default=0, help="Start searching from this block")
 
     def add_p_sender(p):
         p.add_argument("--sender", default=None, help="Account to set as sender (by default we use the current identity)")

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -102,7 +102,7 @@ def add_identity_options(parser, config):
     subparsers = parser.add_subparsers(title="actions", metavar="ACTION")
     subparsers.required = True
 
-    p = subparsers.add_parser("list", help="List of identies")
+    p = subparsers.add_parser("list", help="List of identities")
     p.set_defaults(fn="list")
 
     p = subparsers.add_parser("create", help="Create a new identity")
@@ -120,7 +120,7 @@ def add_identity_options(parser, config):
     p = subparsers.add_parser("delete", help="Delete an identity")
     p.set_defaults(fn="delete")
 
-    identity_names = config.get_all_identies_names()
+    identity_names = config.get_all_identities_names()
 
     p.add_argument("identity_name", choices=identity_names,
                    help="name of identity to delete from {}".format(identity_names), metavar="IDENTITY_NAME")
@@ -218,7 +218,7 @@ def add_organization_options(parser):
     add_contract_identity_arguments(p, [("registry", "registry_at")])
     add_eth_call_arguments(p)
 
-    p = subparsers.add_parser("info", help="Organization's Informations")
+    p = subparsers.add_parser("info", help="Organization's Information")
     p.set_defaults(fn="info")
     add_p_org_id(p)
     add_contract_identity_arguments(p, [("registry", "registry_at")])
@@ -370,7 +370,7 @@ def add_mpe_account_options(parser):
     def add_p_snt_address_opt(p):
         p.add_argument("--singularitynettoken-at", "--snt", default=None,  help="address of SingularityNetToken contract, if not specified we read address from \"networks\"")
 
-    p = subparsers.add_parser("print", help="print the currect ETH account")
+    p = subparsers.add_parser("print", help="print the current ETH account")
     p.set_defaults(fn="print_account")
     add_eth_call_arguments(p)
 
@@ -397,7 +397,7 @@ def add_mpe_account_options(parser):
     p = subparsers.add_parser("transfer", help="transfer AGI tokens inside MPE wallet")
     p.set_defaults(fn="transfer_in_mpe")
     p.add_argument("receiver", help="address of the receiver")
-    p.add_argument("amount",   type=stragi2cogs, help="amount of AGI tokens to be transfered to another account inside MPE wallet")
+    p.add_argument("amount",   type=stragi2cogs, help="amount of AGI tokens to be transferred to another account inside MPE wallet")
     add_p_mpe_address_opt(p)
     add_transaction_arguments(p)
 
@@ -451,13 +451,13 @@ def add_mpe_channel_options(parser):
     add_p_channel_id(p)
     add_eth_call_arguments(p)
 
-    p = subparsers.add_parser("open-init", help="Open and initilize channel using metadata from Registry")
+    p = subparsers.add_parser("open-init", help="Open and initialize channel using metadata from Registry")
     p.set_defaults(fn="open_init_channel_from_registry")
     add_p_service_in_registry(p)
     add_p_open_channel_basic(p)
 
 
-    p = subparsers.add_parser("open-init-metadata", help="Open and initilize channel using service metadata")
+    p = subparsers.add_parser("open-init-metadata", help="Open and initialize channel using service metadata")
     p.set_defaults(fn="open_init_channel_from_metadata")
     add_p_service_in_registry(p)
     add_p_open_channel_basic(p)
@@ -487,7 +487,7 @@ def add_mpe_channel_options(parser):
     add_p_channel_id(p)
     add_p_set_for_extend_add(p)
 
-    p = subparsers.add_parser("extend-add-for-service", help="Set new expiration and add funds for the channel which was initilized for the given service")
+    p = subparsers.add_parser("extend-add-for-service", help="Set new expiration and add funds for the channel which was initialized for the given service")
     p.set_defaults(fn="channel_extend_and_add_funds_for_service")
     add_p_service_in_registry(p)
     add_p_set_for_extend_add(p)
@@ -582,11 +582,11 @@ def add_mpe_client_options(parser):
     p.set_defaults(fn="call_server_statelessly")
     add_p_org_id_service_id(p)
     add_p_set1_for_call(p)
-    p.add_argument("--channel-id", type=int, help="channel_id (only in case of multiply initilized channels for the same payment group)")
+    p.add_argument("--channel-id", type=int, help="channel_id (only in case of multiply initialized channels for the same payment group)")
     p.add_argument("--yes", "-y", action="store_true", help="skip interactive confirmation of call price", default=False)
 
 
-    p = subparsers.add_parser("call-lowlevel", help="Low level function for calling the server. Service should be already initilized.")
+    p = subparsers.add_parser("call-lowlevel", help="Low level function for calling the server. Service should be already initialized.")
     p.set_defaults(fn="call_server_lowlevel")
     add_p_org_id_service_id(p)
     add_p_channel_id(p)
@@ -655,7 +655,7 @@ def add_mpe_service_options(parser):
         p.add_argument("--update-mpe-address" , action='store_true', help="Update mpe_address in metadata before publishing them")
         add_p_mpe_address_opt(p)
 
-    p = subparsers.add_parser("publish-in-ipfs", help="Publish metadata only in IPFS, without publising in Registry")
+    p = subparsers.add_parser("publish-in-ipfs", help="Publish metadata only in IPFS, without publishing in Registry")
     p.set_defaults(fn="publish_metadata_in_ipfs")
     add_p_publish_params(p)
 

--- a/snet_cli/commands.py
+++ b/snet_cli/commands.py
@@ -102,6 +102,9 @@ class BlockchainCommand(Command):
     def get_mpe_address(self):
         return get_contract_address(self, "MultiPartyEscrow")
 
+    def get_registry_address(self):
+        return get_contract_address(self, "Registry")
+
     def get_identity(self):
         identity_type = self.config.get_session_field("identity_type")
 

--- a/snet_cli/commands.py
+++ b/snet_cli/commands.py
@@ -169,7 +169,7 @@ class IdentityCommand(Command):
         identity = {}
 
         identity_name = self.args.identity_name
-        self._ensure(not identity_name in self.config.get_all_identies_names(), "identity_name {} already exists".format(identity_name))
+        self._ensure(not identity_name in self.config.get_all_identities_names(), "identity_name {} already exists".format(identity_name))
 
         identity_type = self.args.identity_type
         identity["identity_type"] = identity_type

--- a/snet_cli/config.py
+++ b/snet_cli/config.py
@@ -50,7 +50,7 @@ class Config(ConfigParser):
         self._persist()
 
     def set_session_identity(self, identity, out_f):
-        if (identity not in self.get_all_identies_names()):
+        if (identity not in self.get_all_identities_names()):
             raise Exception('Identity "%s" is not in config'%identity)
         network = self._get_identity_section(identity).get("network")
         if (network):
@@ -132,7 +132,7 @@ class Config(ConfigParser):
         self[identity_section] = identity
         self._persist()
         # switch to it, if it was the first identity
-        if (len(self.get_all_identies_names()) == 1):
+        if (len(self.get_all_identities_names()) == 1):
             print("You've just added your first identity %s. We will automatically switch to it!"%identity_name)
             self.set_session_identity(identity_name, out_f)
 
@@ -156,14 +156,14 @@ class Config(ConfigParser):
         self["ipfs"]["default_ipfs_endpoint"] = ipfs_endpoint
         self._persist()
 
-    def get_all_identies_names(self):
+    def get_all_identities_names(self):
         return [x[len("identity."):] for x in self.sections() if x.startswith("identity.")]
 
     def get_all_networks_names(self):
         return [x[len("network."):] for x in self.sections() if x.startswith("network.")]
 
     def delete_identity(self, identity_name):
-        if (identity_name not in self.get_all_identies_names()):
+        if (identity_name not in self.get_all_identities_names()):
             raise Exception("identity_name {} does not exist".format(identity_name))
 
         session_identity, _ = self.safe_get_session_identity_network_names()

--- a/snet_cli/mpe_channel_command.py
+++ b/snet_cli/mpe_channel_command.py
@@ -1,3 +1,4 @@
+
 from snet_cli.mpe_service_command import MPEServiceCommand
 from snet_cli.utils import compile_proto
 import base64
@@ -12,30 +13,38 @@ from snet_cli.utils_agi2cogs import cogs2stragi
 import pickle
 from web3.utils.encoding import pad_hex
 from web3.utils.events import get_event_data
-
+from collections import defaultdict
+import json
 
 # we inherit MPEServiceCommand because we need _get_service_metadata_from_registry
 class MPEChannelCommand(MPEServiceCommand):
 
     def _get_persistent_mpe_dir(self):
         """ get persistent storage for mpe """
-        return Path.home().joinpath(".snet", "mpe_client")
+        mpe_address      = self.get_mpe_address().lower()
+        registry_address = self.get_registry_address().lower()
+        return Path.home().joinpath(".snet", "mpe_client", "%s_%s"%(mpe_address, registry_address))
 
-    def _get_channel_dir(self, channel_id):
-        """ get persistent storage for the given channel (~/.snet/mpe_client/<mpe_address>/<channel-id>/) """
-        mpe_address = self.get_mpe_address().lower()
-        return self._get_persistent_mpe_dir().joinpath(mpe_address, str(channel_id))
+    def _get_service_base_dir(self, org_id, service_id):
+        """ get persistent storage for the given service (~/.snet/mpe_client/<mpe_address>_<registry_address>/<org_id>/<service_id>/) """
+        return self._get_persistent_mpe_dir().joinpath(org_id, service_id)
 
-    def get_channel_dir(self):
-        return self._get_channel_dir(self.args.channel_id)
+    def get_service_spec_dir(self, org_id, service_id):
+        """ get persistent storage for the given service (~/.snet/mpe_client/<mpe_address>/<org_id>/<service_id>/service/) """
+        return self._get_service_base_dir(org_id, service_id).joinpath("service")
 
-    def _save_channel_info_dir(self, channel_dir, channel_info):
+    def get_channel_dir(self, org_id, service_id, channel_id):
+        return self._get_service_base_dir(org_id, service_id).joinpath("channels", str(channel_id))
+
+    def _save_channel_info(self, channel_dir, channel_info):
         fn = os.path.join(channel_dir, "channel_info.pickle")
         pickle.dump( channel_info, open( fn, "wb" ) )
 
-    def _read_channel_info(self, channel_id):
-        fn = os.path.join(self._get_channel_dir(channel_id), "channel_info.pickle")
-        return pickle.load( open( fn, "rb" ) )
+    def _read_channel_info(self, org_id, service_id, channel_id):
+        fn = os.path.join(self.get_channel_dir(org_id, service_id, channel_id), "channel_info.pickle")
+        channel_info = pickle.load( open( fn, "rb" ) )
+        channel_info["channelId"] = channel_id
+        return channel_info
 
     def _check_mpe_address_metadata(self, metadata):
         """ we make sure that MultiPartyEscrow address from metadata is correct """
@@ -43,30 +52,45 @@ class MPEChannelCommand(MPEServiceCommand):
         if (str(mpe_address).lower() != str(metadata["mpe_address"]).lower()):
             raise Exception("MultiPartyEscrow contract address from metadata %s do not correspond to current MultiPartyEscrow address %s"%(metadata["mpe_address"], mpe_address))
 
-    def _init_channel_from_metadata(self, channel_dir, metadata, channel_info):
+    def _init_new_service_from_metadata(self, service_dir, metadata):
         self._check_mpe_address_metadata(metadata)
-        if (os.path.exists(channel_dir)):
-            raise Exception("Directory %s already exists"%channel_dir)
+        if (os.path.exists(service_dir)):
+            raise Exception("Directory %s already exists"%service_dir)
 
-        os.makedirs(channel_dir, mode=0o700)
+        os.makedirs(service_dir, mode=0o700)
         try:
-            spec_dir = os.path.join(channel_dir, "service_spec")
+            spec_dir = os.path.join(service_dir, "service_spec")
             os.makedirs(spec_dir, mode=0o700)
             safe_extract_proto_from_ipfs(self._get_ipfs_client(), metadata["model_ipfs_hash"], spec_dir)
 
             # compile .proto files
-            if (not compile_proto(Path(spec_dir), channel_dir)):
+            if (not compile_proto(Path(spec_dir), service_dir)):
                 raise Exception("Fail to compile %s/*.proto"%spec_dir)
 
             # save service_metadata.json in channel_dir
-            metadata.save_pretty(os.path.join(channel_dir, "service_metadata.json"))
-
-            # save channel_info (we need sender and signer)
-            self._save_channel_info_dir(channel_dir, channel_info)
+            metadata.save_pretty(os.path.join(service_dir, "service_metadata.json"))
         except:
             # it is secure to remove channel_dir, because we've created it
-            shutil.rmtree(channel_dir)
+            shutil.rmtree(service_dir)
             raise
+
+    def _init_or_update_service_from_metadata(self, metadata):
+        tmp_dir = tempfile.mkdtemp()
+        shutil.rmtree(tmp_dir)
+        self._init_new_service_from_metadata(tmp_dir, metadata)
+
+        service_dir = self.get_service_spec_dir(self.args.org_id, self.args.service_id)
+        # it is relatevely safe to remove service_dir because we know that service_dir = self.get_service_spec_dir() so it is not a normal dir
+        if (os.path.exists(service_dir)):
+            shutil.rmtree(service_dir)
+        shutil.move(tmp_dir, service_dir)
+
+    def _init_channel_dir(self, channel_id, channel_info):
+        channel_dir = self.get_channel_dir(self.args.org_id, self.args.service_id, channel_id)
+        if (not os.path.exists(channel_dir)):
+            os.makedirs(channel_dir, mode=0o700)
+        # save channel info
+        self._save_channel_info(channel_dir, channel_info)
 
     def _check_channel_is_mine(self, channel):
         if (channel["sender"].lower() != self.ident.address.lower() and
@@ -74,29 +98,27 @@ class MPEChannelCommand(MPEServiceCommand):
                 raise Exception("Channel does not correspond to the current Ethereum identity " +
                                  "(address=%s sender=%s signer=%s)"%(self.ident.address.lower(), channel["sender"].lower(), channel["signer"].lower()))
 
-    def _try_init_channel_from_metadata(self, metadata):
-        channel = self._get_channel_state_from_blockchain(self.args.channel_id)
+    def _init_channel_from_metadata(self, metadata):
         channel_id = self.args.channel_id
-        if (channel["sender"].lower() != self.ident.address.lower() and
-            channel["signer"].lower() != self.ident.address.lower()):
-                raise Exception("Channel %i does not correspond to the current Ethereum identity "%channel_id +
-                                "(address=%s sender=%s signer=%s)"%(self.ident.address.lower(), channel["sender"].lower(), channel["signer"].lower()))
-        group_name = metadata.get_group_by_group_id(channel["groupId"])
-        if (not group_name):
+        channel = self._get_channel_state_from_blockchain(channel_id)
+        self._check_channel_is_mine(channel)
+        group = metadata.get_group_by_group_id(channel["groupId"])
+        if (group is None):
             group_id_base64 = base64.b64encode(channel["groupId"]).decode('ascii')
             raise Exception("Channel %i does not correspond to the given metadata.\n"%channel_id +
-                             "We canot find the following group_id in metadata: " + group_id_base64)
+                             "We canont find the following group_id in metadata: " + group_id_base64)
         self._printout("#group_name")
-        self._printout(group_name["group_name"])
-        self._init_channel_from_metadata(self.get_channel_dir(), metadata, channel)
+        self._printout(group["group_name"])
+        self._init_or_update_service_from_metadata(metadata)
+        self._init_channel_dir(channel_id, channel)
 
     def init_channel_from_metadata(self):
         metadata  = load_mpe_service_metadata(self.args.metadata_file)
-        self._try_init_channel_from_metadata(metadata)
+        self._init_channel_from_metadata(metadata)
 
     def init_channel_from_registry(self):
         metadata      = self._get_service_metadata_from_registry()
-        self._try_init_channel_from_metadata(metadata)
+        self._init_channel_from_metadata(metadata)
 
     def _get_expiration_from_args(self):
         """
@@ -130,10 +152,7 @@ class MPEChannelCommand(MPEServiceCommand):
         group_id    = metadata.get_group_id(self.args.group_name)
         recipient   = metadata.get_payment_address(self.args.group_name)
 
-        if (self.args.signer):
-            signer = self.args.signer
-        else:
-            signer = self.ident.address
+        signer = self.get_address_from_arg_or_ident(self.args.signer)
 
         channel_info = {"sender": self.ident.address, "signer": signer, "recipient": recipient, "groupId" : group_id}
         expiration = self._get_expiration_from_args()
@@ -144,20 +163,41 @@ class MPEChannelCommand(MPEServiceCommand):
             raise Exception("We've expected only one ChannelOpen event after openChannel. Make sure that you use correct MultiPartyEscrow address")
         return rez[1][0]["args"]["channelId"], channel_info
 
+    def _find_already_opened_channel(self, metadata):
+        sender    = self.ident.address
+        signer    = self.get_address_from_arg_or_ident(self.args.signer)
+        group_id  = metadata.get_group_id(self.args.group_name)
+
+        channels_ids = self._get_all_channels_filter_group_sender(group_id, sender)
+        for i in channels_ids:
+            channel = self._get_channel_state_from_blockchain(i)
+            if (channel["signer"].lower() == signer.lower()):
+                return i, channel
+        return None, None
+
     def _open_init_channel_from_metadata(self, metadata):
-        """ try to initialize channel without actually open it (we check metadata and we compile .proto files) """
+
+        # first we simply try to initialize service without open channel (we check metadata and we compile .proto files) """
         tmp_dir = tempfile.mkdtemp()
         shutil.rmtree(tmp_dir)
-        self._init_channel_from_metadata(tmp_dir, metadata, {})
+        self._init_new_service_from_metadata(tmp_dir, metadata)
         shutil.rmtree(tmp_dir)
 
-        # open payment channel
-        channel_id, channel_info = self._open_channel_for_service(metadata)
-        self._printout("#channel_id")
-        self._printout(channel_id)
+        # first we try to find channel for this service
+        if (not self.args.open_new_anyway):
+            channel_id, channel_info = self._find_already_opened_channel(metadata)
+        if (not self.args.open_new_anyway and channel_id is not None):
+            self._printout("Channel with given sender, signer and group_id is already exists we simply initilize it")
+            self._printout("Please run 'snet channel extend-add %i --expiration <EXPIRATION> --amount <AMOUNT>' if necessary"%channel_id)
+        else:
+            # open payment channel
+            channel_id, channel_info = self._open_channel_for_service(metadata)
+            self._printout("#channel_id")
+            self._printout(channel_id)
 
         # initialize new channel
-        self._init_channel_from_metadata(self._get_channel_dir(channel_id), metadata, channel_info)
+        self._init_or_update_service_from_metadata(metadata)
+        self._init_channel_dir(channel_id, channel_info)
 
     def open_init_channel_from_metadata(self):
         metadata  = load_mpe_service_metadata(self.args.metadata_file)
@@ -178,13 +218,25 @@ class MPEChannelCommand(MPEServiceCommand):
         self.transact_contract_command("MultiPartyEscrow", "channelExtendAndAddFunds", [self.args.channel_id, expiration, self.args.amount])
 
     def _get_all_initilized_channels(self):
-        """ return list of tuples (channel_id, channel_info) """
-        channels = []
-        for channel_dir in self._get_channel_dir(0).parent.glob("*"):
-            if (channel_dir.name.isdigit()):
+        """ return dict of lists  rez[(<org_id>, <service_id>)] = [(channel_id, channel_info)] """
+        channels_dict = defaultdict(list)
+
+        for channel_dir in self._get_persistent_mpe_dir().glob("*/*/*/*"):
+            if (channel_dir.name.isdigit() and channel_dir.parent.name == "channels"):
+                org_id = channel_dir.parent.parent.parent.name
+                service_id = channel_dir.parent.parent.name
                 channel_id    = int(channel_dir.name)
-                channel_info  = self._read_channel_info(channel_id)
-                channels.append((channel_id, channel_info))
+                channel_info  = self._read_channel_info(org_id, service_id, channel_id)
+                channels_dict[(org_id, service_id)].append(channel_info)
+        return channels_dict
+
+    def _get_initilized_channels_for_service(self, org_id, service_id):
+        channels = []
+        for channel_dir in self._get_service_base_dir(org_id, service_id).glob("*/*"):
+            if (channel_dir.name.isdigit() and channel_dir.parent.name == "channels"):
+                channel_id    = int(channel_dir.name)
+                channel_info  = self._read_channel_info(org_id, service_id, channel_id)
+                channels.append(channel_info)
         return channels
 
     def _get_channel_state_from_blockchain(self, channel_id):
@@ -193,6 +245,12 @@ class MPEChannelCommand(MPEServiceCommand):
         channel     = self.call_contract_command("MultiPartyEscrow",  "channels", [channel_id])
         channel     = abi_decode_struct_to_dict(channel_abi, channel)
         return channel
+
+    def _read_metadata_for_service(self, org_id, service_id):
+        sdir = self.get_service_spec_dir(org_id, service_id)
+        if (not os.path.exists(sdir)):
+            raise Exception("Service with org_id=%s and service_id=%s is not initilized"%(org_id, service_id))
+        return load_mpe_service_metadata(sdir.joinpath("service_metadata.json"))
 
     def _print_channels_from_blockchain(self, channels_ids):
         channels_ids = sorted(channels_ids)
@@ -206,36 +264,52 @@ class MPEChannelCommand(MPEServiceCommand):
             value_agi = cogs2stragi(channel["value"])
             group_id_base64 = base64.b64encode(channel["groupId"]).decode("ascii")
             self._printout("%i %i %s %s %s %i"%(i, channel["nonce"], channel["recipient"], group_id_base64,
-                                                   value_agi, channel["expiration"]))
+                                                value_agi, channel["expiration"]))
 
-    def _filter_channels_sender_signer(self, channels):
-        good_id = []
-        for channel_id, channel_info in channels:
-            not_sender = channel_info["sender"] != self.ident.address
-            not_signer = channel_info["signer"] != self.ident.address
+    def _print_channels_dict_from_blockchain(self, channels_dict):
+        # print only caption
+        if (self.args.only_id):
+            self._printout("#organization_id service_id channelId")
+        else:
+            self._printout("#organization_id service_id group_name channel_id nonce value(AGI) expiration(blocks)")
+        for org_id, service_id in channels_dict:
+            channels = self._filter_channels_sender_or_signer(channels_dict[org_id, service_id])
+            metadata = self._read_metadata_for_service(org_id, service_id)
+            for channel in channels:
+                channel_id = channel["channelId"]
+                group = metadata.get_group_by_group_id(channel["groupId"])
+                if (group is None):
+                    group_name = "UNDIFINED"
+                else:
+                    group_name = group["group_name"]
+                if (self.args.only_id):
+                    self._printout("%s %s %s %i"%(org_id, service_id, group_name, channel_id))
+                else:
+                    channel_blockchain = self._get_channel_state_from_blockchain(channel_id)
+                    value_agi  = cogs2stragi(channel_blockchain["value"])
+                    self._printout("%s %s %s %i %i %s %i"%(org_id, service_id, group_name, channel_id, channel_blockchain["nonce"], value_agi, channel_blockchain["expiration"]))
+
+    def _filter_channels_sender_or_signer(self, channels):
+        good_channels = []
+        for channel in channels:
+            not_sender = channel["sender"] != self.ident.address
+            not_signer = channel["signer"] != self.ident.address
             if (self.args.filter_sender and not_sender):
                 continue
             if (self.args.filter_signer and not_signer):
                 continue
             if (self.args.filter_my and not_sender and not_signer):
                 continue
-            good_id.append(channel_id)
-        return good_id
+            good_channels.append(channel)
+        return good_channels
 
     def print_initialized_channels(self):
-        channels = self._get_all_initilized_channels()
-        good_ids = self._filter_channels_sender_signer(channels)
-        self._print_channels_from_blockchain(good_ids)
+        channels_dict = self._get_all_initilized_channels()
+        self._print_channels_dict_from_blockchain(channels_dict)
 
-    def print_initialized_channels_filter_group(self):
-        channels = self._get_all_initilized_channels()
-        metadata = self._get_service_metadata_from_registry()
-        group_id = metadata.get_group_id(self.args.group_name)
-
-        # filter channels for specific group_id
-        channels = [(cid, cinfo) for cid, cinfo in channels if (cinfo["groupId"] == group_id)]
-        good_ids = self._filter_channels_sender_signer(channels)
-        self._print_channels_from_blockchain(good_ids)
+    def print_initialized_channels_filter_service(self):
+        channels = self._get_initilized_channels_for_service(self.args.org_id, self.args.service_id)
+        self._print_channels_dict_from_blockchain({(self.args.org_id, self.args.service_id):channels})
 
     def _get_all_filtered_channels(self, topics_without_signature):
         """ get all filtered chanels from blockchain logs """
@@ -272,15 +346,17 @@ class MPEChannelCommand(MPEServiceCommand):
         channels_ids = self._get_all_filtered_channels([None, None, group_id_hex])
         self._print_channels_from_blockchain(channels_ids)
 
+    def _get_all_channels_filter_group_sender(self, group_id, sender):
+        address_padded = pad_hex(sender.lower(), 256)
+        group_id_hex = "0x" + group_id.hex()
+        return self._get_all_filtered_channels([address_padded, None, group_id_hex])
+
     def print_all_channels_filter_group_sender(self):
         address = self.get_address_from_arg_or_ident(self.args.sender)
-        address_padded = pad_hex(address.lower(), 256)
         metadata = self._get_service_metadata_from_registry()
         group_id = metadata.get_group_id(self.args.group_name)
-        group_id_hex = "0x" + group_id.hex()
-        channels_ids = self._get_all_filtered_channels([address_padded, None, group_id_hex])
+        channels_ids = self._get_all_channels_filter_group_sender(group_id, address)
         self._print_channels_from_blockchain(channels_ids)
-
     #Auxilary functions
     def print_block_number(self):
          self._printout(self.ident.w3.eth.blockNumber)

--- a/snet_cli/mpe_channel_command.py
+++ b/snet_cli/mpe_channel_command.py
@@ -225,6 +225,18 @@ class MPEChannelCommand(MPEServiceCommand):
         expiration = self._get_expiration_from_args()
         self.transact_contract_command("MultiPartyEscrow", "channelExtendAndAddFunds", [self.args.channel_id, expiration, self.args.amount])
 
+    def channel_extend_and_add_funds_for_service(self):
+        expiration = self._get_expiration_from_args()
+        channels = self._get_initilized_channels_for_service(self.args.org_id, self.args.service_id)
+        channels = [c for c in channels if c["sender"].lower() == self.ident.address.lower()]
+        if (len(channels) == 0):
+            raise Exception("Cannot find initilized channel for service with org_id=%s service_id=%s and sender=%s"%(self.args.org_id, self.args.service_id, self.ident.adress))
+        if (len(channels) > 1):
+            channel_ids = [channel["channelId"] for channel in channels]
+            raise Exception("We have several initilized channel: %s. You should use 'snet channel extend-add' for selected channel"%str(channel_ids))
+        channel_id = channels[0]["channelId"]
+        self.transact_contract_command("MultiPartyEscrow", "channelExtendAndAddFunds", [channel_id, expiration, self.args.amount])
+
     def _get_all_initilized_channels(self):
         """ return dict of lists  rez[(<org_id>, <service_id>)] = [(channel_id, channel_info)] """
         channels_dict = defaultdict(list)

--- a/snet_cli/mpe_channel_command.py
+++ b/snet_cli/mpe_channel_command.py
@@ -105,7 +105,7 @@ class MPEChannelCommand(MPEServiceCommand):
         if (group is None):
             group_id_base64 = base64.b64encode(channel["groupId"]).decode('ascii')
             raise Exception("Channel %i does not correspond to the given metadata.\n"%channel_id +
-                             "We canont find the following group_id in metadata: " + group_id_base64)
+                             "We can't find the following group_id in metadata: " + group_id_base64)
         self._printout("#group_name")
         self._printout(group["group_name"])
         self._init_or_update_service_from_metadata(metadata)
@@ -168,7 +168,7 @@ class MPEChannelCommand(MPEServiceCommand):
         group_id  = metadata.get_group_id(self.args.group_name)
         recipient = metadata.get_group(self.args.group_name)["payment_address"]
 
-        channels_ids = self._get_all_channels_filter_sender_recipeint_group(sender, recipient, group_id)
+        channels_ids = self._get_all_channels_filter_sender_recipient_group(sender, recipient, group_id)
         for i in channels_ids:
             channel = self._get_channel_state_from_blockchain(i)
             if (channel["signer"].lower() == signer.lower()):
@@ -187,7 +187,7 @@ class MPEChannelCommand(MPEServiceCommand):
         if (not self.args.open_new_anyway):
             channel_id, channel_info = self._find_already_opened_channel(metadata)
         if (not self.args.open_new_anyway and channel_id is not None):
-            self._printout("Channel with given sender, signer and group_id is already exists we simply initilize it (channel_id = %i)"%channel_id)
+            self._printout("Channel with given sender, signer and group_id is already exists we simply initialize it (channel_id = %i)"%channel_id)
             self._printout("Please run 'snet channel extend-add %i --expiration <EXPIRATION> --amount <AMOUNT>' if necessary"%channel_id)
         else:
             # open payment channel
@@ -226,17 +226,17 @@ class MPEChannelCommand(MPEServiceCommand):
 
     def channel_extend_and_add_funds_for_service(self):
         expiration = self._get_expiration_from_args()
-        channels = self._get_initilized_channels_for_service(self.args.org_id, self.args.service_id)
+        channels = self._get_initialized_channels_for_service(self.args.org_id, self.args.service_id)
         channels = [c for c in channels if c["sender"].lower() == self.ident.address.lower()]
         if (len(channels) == 0):
-            raise Exception("Cannot find initilized channel for service with org_id=%s service_id=%s and sender=%s"%(self.args.org_id, self.args.service_id, self.ident.adress))
+            raise Exception("Cannot find initialized channel for service with org_id=%s service_id=%s and sender=%s"%(self.args.org_id, self.args.service_id, self.ident.adress))
         if (len(channels) > 1):
             channel_ids = [channel["channelId"] for channel in channels]
-            raise Exception("We have several initilized channel: %s. You should use 'snet channel extend-add' for selected channel"%str(channel_ids))
+            raise Exception("We have several initialized channel: %s. You should use 'snet channel extend-add' for selected channel"%str(channel_ids))
         channel_id = channels[0]["channelId"]
         self.transact_contract_command("MultiPartyEscrow", "channelExtendAndAddFunds", [channel_id, expiration, self.args.amount])
 
-    def _get_all_initilized_channels(self):
+    def _get_all_initialized_channels(self):
         """ return dict of lists  rez[(<org_id>, <service_id>)] = [(channel_id, channel_info)] """
         channels_dict = defaultdict(list)
 
@@ -249,7 +249,7 @@ class MPEChannelCommand(MPEServiceCommand):
                 channels_dict[(org_id, service_id)].append(channel_info)
         return channels_dict
 
-    def _get_initilized_channels_for_service(self, org_id, service_id):
+    def _get_initialized_channels_for_service(self, org_id, service_id):
         channels = []
         for channel_dir in self._get_service_base_dir(org_id, service_id).glob("*/*"):
             if (channel_dir.name.isdigit() and channel_dir.parent.name == "channels"):
@@ -268,7 +268,7 @@ class MPEChannelCommand(MPEServiceCommand):
     def _read_metadata_for_service(self, org_id, service_id):
         sdir = self.get_service_spec_dir(org_id, service_id)
         if (not os.path.exists(sdir)):
-            raise Exception("Service with org_id=%s and service_id=%s is not initilized"%(org_id, service_id))
+            raise Exception("Service with org_id=%s and service_id=%s is not initialized"%(org_id, service_id))
         return load_mpe_service_metadata(sdir.joinpath("service_metadata.json"))
 
     def _print_channels_from_blockchain(self, channels_ids):
@@ -323,11 +323,11 @@ class MPEChannelCommand(MPEServiceCommand):
         return good_channels
 
     def print_initialized_channels(self):
-        channels_dict = self._get_all_initilized_channels()
+        channels_dict = self._get_all_initialized_channels()
         self._print_channels_dict_from_blockchain(channels_dict)
 
     def print_initialized_channels_filter_service(self):
-        channels = self._get_initilized_channels_for_service(self.args.org_id, self.args.service_id)
+        channels = self._get_initialized_channels_for_service(self.args.org_id, self.args.service_id)
         self._print_channels_dict_from_blockchain({(self.args.org_id, self.args.service_id):channels})
 
     def _get_all_filtered_channels(self, topics_without_signature):
@@ -378,7 +378,7 @@ class MPEChannelCommand(MPEServiceCommand):
         channels_ids = self._get_all_filtered_channels([sender_padded])
         return channels_ids
 
-    def _get_all_channels_filter_sender_recipeint_group(self, sender, recipient, group_id):
+    def _get_all_channels_filter_sender_recipient_group(self, sender, recipient, group_id):
         sender_padded    = pad_hex(sender.lower(),    256)
         recipient_padded = pad_hex(recipient.lower(), 256)
         group_id_hex = "0x" + group_id.hex()

--- a/snet_cli/mpe_channel_command.py
+++ b/snet_cli/mpe_channel_command.py
@@ -14,7 +14,6 @@ import pickle
 from web3.utils.encoding import pad_hex
 from web3.utils.events import get_event_data
 from collections import defaultdict
-import json
 
 # we inherit MPEServiceCommand because we need _get_service_metadata_from_registry
 class MPEChannelCommand(MPEServiceCommand):

--- a/snet_cli/mpe_client_command.py
+++ b/snet_cli/mpe_client_command.py
@@ -246,6 +246,10 @@ class MPEClientCommand(MPEChannelCommand):
         price         = self._get_price_from_metadata(service_metadata)
         server_state  = self._get_channel_state_from_server(grpc_channel, channel_id)
 
+        proceed = self.args.yes or input("Price for this call will be %s AGI (use -y to remove this warning). Proceed? (y/n): "%(cogs2stragi(price))) == "y"
+        if (not proceed):
+            self._error("Cancelled")
+
         response = self._call_server_via_grpc_channel(grpc_channel, channel_id, server_state["current_nonce"], server_state["current_signed_amount"] + price, params, service_metadata)
         return response
 

--- a/snet_cli/mpe_client_command.py
+++ b/snet_cli/mpe_client_command.py
@@ -6,7 +6,7 @@ import json
 import sys
 import grpc
 from eth_account.messages import defunct_hash_message
-from snet_cli.utils_proto import import_protobuf_from_dir, switch_to_json_payload_econding
+from snet_cli.utils_proto import import_protobuf_from_dir, switch_to_json_payload_encoding
 from snet_cli.utils_agi2cogs import cogs2stragi
 from snet_cli.utils import remove_http_https_prefix
 
@@ -102,7 +102,7 @@ class MPEClientCommand(MPEChannelCommand):
         call_fn  = getattr(stub, self.args.method)
 
         if service_metadata["encoding"] == "json":
-            switch_to_json_payload_econding(call_fn, response_class)
+            switch_to_json_payload_encoding(call_fn, response_class)
 
         mpe_address = self.get_mpe_address()
         signature = self._sign_message(mpe_address, channel_id, nonce, amount)
@@ -213,19 +213,19 @@ class MPEClientCommand(MPEChannelCommand):
         self._printout("current_unspent_amount_in_cogs = %s"%str(unspent_amount))
 
     def _get_channel_for_call(self):
-        channels = self._get_initilized_channels_for_service(self.args.org_id, self.args.service_id)
+        channels = self._get_initialized_channels_for_service(self.args.org_id, self.args.service_id)
         channels = [c for c in channels if c["signer"].lower() == self.ident.address.lower()]
         if (len(channels) == 0):
-            raise Exception("Cannot find initilized channel for service with org_id=%s service_id=%s and signer=%s"%(self.args.org_id, self.args.service_id, self.ident.adress))
+            raise Exception("Cannot find initialized channel for service with org_id=%s service_id=%s and signer=%s"%(self.args.org_id, self.args.service_id, self.ident.adress))
         if (self.args.channel_id is None):
             if (len(channels) > 1):
                 channel_ids = [channel["channelId"] for channel in channels]
-                raise Exception("We have several initilized channel: %s. You should use --channel-id to select one"%str(channel_ids))
+                raise Exception("We have several initialized channel: %s. You should use --channel-id to select one"%str(channel_ids))
             return channels[0]
         for channel in channels:
             if (channel["channelId"] == self.args.channel_id):
                 return channel
-        raise Exception("Channel %i has not been initilized or your are not the signer of it"%self.args.channel_id)
+        raise Exception("Channel %i has not been initialized or your are not the signer of it"%self.args.channel_id)
 
     def _get_price_from_metadata(self, service_metadata):
         pricing = service_metadata["pricing"]

--- a/snet_cli/mpe_client_command.py
+++ b/snet_cli/mpe_client_command.py
@@ -4,11 +4,9 @@ import base64
 from pathlib import Path
 import json
 import sys
-import os
 import grpc
 from eth_account.messages import defunct_hash_message
 from snet_cli.utils_proto import import_protobuf_from_dir, switch_to_json_payload_econding
-from snet_cli.mpe_service_metadata import load_mpe_service_metadata
 from snet_cli.utils_agi2cogs import cogs2stragi
 from snet_cli.utils import remove_http_https_prefix
 

--- a/snet_cli/mpe_client_command.py
+++ b/snet_cli/mpe_client_command.py
@@ -63,7 +63,7 @@ class MPEClientCommand(MPEChannelCommand):
 
         return params
 
-    
+
     def _transform_call_params(self, params):
         """
         possible modifiers: file, b64encode, b64decode
@@ -92,12 +92,12 @@ class MPEClientCommand(MPEChannelCommand):
             rez[k_final] = v
         return rez
 
-    def _import_protobuf_for_channel(self):
-        channel_dir = self.get_channel_dir()
-        return import_protobuf_from_dir(channel_dir, self.args.method, self.args.service)
+    def _import_protobuf_for_service(self):
+        spec_dir = self.get_service_spec_dir(self.args.org_id, self.args.service_id)
+        return import_protobuf_from_dir(spec_dir, self.args.method, self.args.service)
 
-    def _call_server_via_grpc_channel(self, grpc_channel, nonce, amount, params, service_metadata):
-        stub_class, request_class, response_class = self._import_protobuf_for_channel()
+    def _call_server_via_grpc_channel(self, grpc_channel, channel_id, nonce, amount, params, service_metadata):
+        stub_class, request_class, response_class = self._import_protobuf_for_service()
 
         request  = request_class(**params)
         stub     = stub_class(grpc_channel)
@@ -107,7 +107,6 @@ class MPEClientCommand(MPEChannelCommand):
             switch_to_json_payload_econding(call_fn, response_class)
 
         mpe_address = self.get_mpe_address()
-        channel_id  = self.args.channel_id
         signature = self._sign_message(mpe_address, channel_id, nonce, amount)
         metadata = [("snet-payment-type",                 "escrow"                    ),
                     ("snet-payment-channel-id",            str(channel_id)  ),
@@ -116,11 +115,6 @@ class MPEClientCommand(MPEChannelCommand):
                     ("snet-payment-channel-signature-bin", bytes(signature))]
         response = call_fn(request, metadata=metadata)
         return response
-
-    def _get_service_metadata_for_channel(self):
-        if (not os.path.exists(self.get_channel_dir())):
-            raise Exception("Channel %i is not initilized"%self.args.channel_id)
-        return load_mpe_service_metadata(self.get_channel_dir().joinpath("service_metadata.json"))
 
     def _deal_with_call_response(self, response):
         if (self.args.save_response):
@@ -138,12 +132,34 @@ class MPEClientCommand(MPEChannelCommand):
         else:
             self._printout(response)
 
+    def _open_grpc_channel(self, endpoint):
+        """
+           open grpc channel:
+               - for http://  we open insecure_channel
+               - for https:// we open secure_channel (with default credentials)
+               - without prefix we open insecure_channel
+        """
+        if (endpoint.startswith("https://")):
+            return grpc.secure_channel(remove_http_https_prefix(endpoint), grpc.ssl_channel_credentials())
+        return grpc.insecure_channel(remove_http_https_prefix(endpoint))
+
+    def _get_endpoint_from_metadata_or_args(self, metadata):
+        if (self.args.endpoint):
+            return self.args.endpoint
+        endpoints = metadata.get_endpoints_for_group(self.args.group_name)
+        if (not endpoints):
+            raise Exception("Cannot find endpoint in metadata for the given payment group.")
+        if (len(endpoints) > 1):
+            self._printerr("There are several endpoints for the given payment group. We will select %s"%endpoints[0])
+        return endpoints[0]
+
     def call_server_lowlevel(self):
         params           = self._get_call_params()
-        grpc_channel     = grpc.insecure_channel(remove_http_https_prefix(self.args.endpoint))
-        service_metadata = self._get_service_metadata_for_channel()
+        service_metadata = self._read_metadata_for_service(self.args.org_id, self.args.service_id)
+        endpoint         = self._get_endpoint_from_metadata_or_args(service_metadata)
+        grpc_channel     = self._open_grpc_channel(endpoint)
 
-        response = self._call_server_via_grpc_channel(grpc_channel, self.args.nonce, self.args.amount, params, service_metadata)
+        response = self._call_server_via_grpc_channel(grpc_channel, self.args.channel_id, self.args.nonce, self.args.amount_in_cogs, params, service_metadata)
         self._deal_with_call_response(response)
 
     # III. Stateless client related functions
@@ -191,31 +207,49 @@ class MPEClientCommand(MPEChannelCommand):
         return (server["current_nonce"], server["current_signed_amount"], unspent_amount)
 
     def print_channel_state_statelessly(self):
-        grpc_channel = grpc.insecure_channel(self.args.endpoint)
+        grpc_channel     = self._open_grpc_channel(self.args.endpoint)
+
         current_nonce, current_amount, unspent_amount = self._get_channel_state_statelessly(grpc_channel, self.args.channel_id)
         self._printout("current_nonce                  = %i"%current_nonce)
         self._printout("current_signed_amount_in_cogs  = %i"%current_amount)
         self._printout("current_unspent_amount_in_cogs = %s"%str(unspent_amount))
 
-    def _call_check_price(self, service_metadata):
-        pricing = service_metadata["pricing"]
-        if (pricing["price_model"] == "fixed_price" and pricing["price_in_cogs"] != self.args.price):
-            raise Exception("Service price is %s, but you set price %s"%(cogs2stragi(pricing["price_in_cogs"]), cogs2stragi(self.args.price)))
+    def _get_channel_for_call(self):
+        channels = self._get_initilized_channels_for_service(self.args.org_id, self.args.service_id)
+        channels = [c for c in channels if c["signer"].lower() == self.ident.address.lower()]
+        if (len(channels) == 0):
+            raise Exception("Cannot find initilized channel for service with org_id=%s service_id=%s and signer=%s"%(self.args.org_id, self.args.service_id, self.ident.adress))
+        if (self.args.channel_id is None):
+            if (len(channels) > 1):
+                channel_ids = [channel["channelId"] for channel in channels]
+                raise Exception("We have several initilized channel: %s. You should use --channel-id to select one"%str(channel_ids))
+            return channels[0]
+        for channel in channels:
+            if (channel["channelId"] == self.args.channel_id):
+                return channel
+        raise Exception("Channel %i has not been initilized or your are not the signer of it"%self.args.channel_id)
 
-    def _call_check_signer(self):
-        channel_info = self._read_channel_info(self.args.channel_id)
-        if (self.ident.address != channel_info["signer"]):
-            raise Exception("You are not the signer of the channel %i"%self.args.channel_id)
+    def _get_price_from_metadata(self, service_metadata):
+        pricing = service_metadata["pricing"]
+        if (pricing["price_model"] == "fixed_price"):
+            return pricing["price_in_cogs"]
+        raise Exception("We do not support price model: %s"%(pricing["price_model"]))
+
+
+    def call_server_statelessly_with_params(self, params):
+        service_metadata = self._read_metadata_for_service(self.args.org_id, self.args.service_id)
+        endpoint         = self._get_endpoint_from_metadata_or_args(service_metadata)
+        grpc_channel     = self._open_grpc_channel(endpoint)
+
+        channel       = self._get_channel_for_call()
+        channel_id    = channel["channelId"]
+        price         = self._get_price_from_metadata(service_metadata)
+        server_state  = self._get_channel_state_from_server(grpc_channel, channel_id)
+
+        response = self._call_server_via_grpc_channel(grpc_channel, channel_id, server_state["current_nonce"], server_state["current_signed_amount"] + price, params, service_metadata)
+        return response
 
     def call_server_statelessly(self):
         params           = self._get_call_params()
-        grpc_channel     = grpc.insecure_channel(remove_http_https_prefix(self.args.endpoint))
-        service_metadata = self._get_service_metadata_for_channel()
-
-        self._call_check_price(service_metadata)
-        self._call_check_signer()
-
-        current_nonce, current_amount, unspent_amount = self._get_channel_state_statelessly(grpc_channel, self.args.channel_id)
-        self._printout("unspent_amount_in_cogs before call (None means that we cannot get it now):%s"%str(unspent_amount))
-        response = self._call_server_via_grpc_channel(grpc_channel, current_nonce, current_amount + self.args.price, params, service_metadata)
+        response = self.call_server_statelessly_with_params(params)
         self._deal_with_call_response(response)

--- a/snet_cli/mpe_service_command.py
+++ b/snet_cli/mpe_service_command.py
@@ -108,6 +108,19 @@ class MPEServiceCommand(BlockchainCommand):
         self.transact_contract_command("Registry", "createServiceRegistration", params)
 
     def publish_metadata_in_ipfs_and_update_registration(self):
+        # first we check that we do not change payment_address or group_id in existed payment groups
+        if (not self.args.force):
+            old_metadata = self._get_service_metadata_from_registry()
+            new_metadata = load_mpe_service_metadata(self.args.metadata_file)
+            for old_group in old_metadata["groups"]:
+                if (new_metadata.is_group_name_exists(old_group["group_name"])):
+
+                    new_group = new_metadata.get_group(old_group["group_name"])
+                    if (new_group["group_id"] != old_group["group_id"] or new_group["payment_address"] != old_group["payment_address"]):
+                        raise Exception("You are trying to change group_id or payment_address in group '%s'.\n"%old_group["group_name"] +
+                                         "You will make all opennned channels invalid.\n" +
+                                         "Use --force if you really want it.")
+
         metadata_uri     = hash_to_bytesuri( self._publish_metadata_in_ipfs(self.args.metadata_file))
         params           = [type_converter("bytes32")(self.args.org_id), type_converter("bytes32")(self.args.service_id), metadata_uri]
         self.transact_contract_command("Registry", "updateServiceRegistration", params)

--- a/snet_cli/mpe_service_command.py
+++ b/snet_cli/mpe_service_command.py
@@ -118,7 +118,7 @@ class MPEServiceCommand(BlockchainCommand):
                     new_group = new_metadata.get_group(old_group["group_name"])
                     if (new_group["group_id"] != old_group["group_id"] or new_group["payment_address"] != old_group["payment_address"]):
                         raise Exception("You are trying to change group_id or payment_address in group '%s'.\n"%old_group["group_name"] +
-                                         "You will make all opennned channels invalid.\n" +
+                                         "You will make all open channels invalid.\n" +
                                          "Use --force if you really want it.")
 
         metadata_uri     = hash_to_bytesuri( self._publish_metadata_in_ipfs(self.args.metadata_file))

--- a/snet_cli/mpe_service_metadata.py
+++ b/snet_cli/mpe_service_metadata.py
@@ -44,7 +44,7 @@ from snet_cli.utils import is_valid_endpoint
 
 # TODO: we should use some standard solution here
 class MPEServiceMetadata:
-    
+
     def __init__(self):
         """ init with modelIPFSHash """
         self.m = {"version"        : 1,
@@ -164,6 +164,10 @@ class MPEServiceMetadata:
 
     def get_all_endpoints(self):
         return [e["endpoint"] for e in self.m["endpoints"]]
+
+    def get_endpoints_for_group(self, group_name = None):
+        group_name = self.get_group_name_nonetrick(group_name)
+        return [e["endpoint"] for e in self.m["endpoints"] if e["group_name"] == group_name]
 
 def load_mpe_service_metadata(f):
     metadata = MPEServiceMetadata()

--- a/snet_cli/mpe_service_metadata.py
+++ b/snet_cli/mpe_service_metadata.py
@@ -62,7 +62,7 @@ class MPEServiceMetadata:
     def set_simple_field(self, f, v):
         if (f != "display_name" and f != "encoding" and f != "model_ipfs_hash" and f != "mpe_address" and
             f != "service_type" and f != "payment_expiration_threshold" and f != "service_description"):
-                raise Exception("unknow field in MPEServiceMetadata")
+                raise Exception("unknown field in MPEServiceMetadata")
         self.m[f] = v
 
     def set_fixed_price_in_cogs(self, price):

--- a/snet_cli/mpe_treasurer_command.py
+++ b/snet_cli/mpe_treasurer_command.py
@@ -94,7 +94,7 @@ class MPETreasurerCommand(MPEChannelCommand):
             amount     = payment["amount"]
             sig        = payment["signature"]
             if (len(sig) != 65):
-                raise Exception("Length of signature is incorect: %i instead of 65"%(len(sig)))
+                raise Exception("Length of signature is incorrect: %i instead of 65"%(len(sig)))
             v, r, s = int(sig[-1]), sig[:32], sig[32:64]
             v = v % 27 + 27
             params     = [channel_id, amount, v , r, s, False]

--- a/snet_cli/utils_ipfs.py
+++ b/snet_cli/utils_ipfs.py
@@ -3,7 +3,6 @@ import tarfile
 import glob
 import io
 import os
-import sys
 
 import base58
 import multihash

--- a/snet_cli/utils_proto.py
+++ b/snet_cli/utils_proto.py
@@ -69,7 +69,7 @@ def _import_protobuf_from_file(grpc_pyfile, method_name, service_name = None):
                         " You should specify service_name."%(method_name, ", ".join(found_services)))
     return True, (stub_class, request_class, response_class)
 
-def switch_to_json_payload_econding(call_fn, response_class):
+def switch_to_json_payload_encoding(call_fn, response_class):
     """ Switch payload encoding to JSON for GRPC call """
     def json_serializer(*args, **kwargs):
         return bytes(json_format.MessageToJson(args[0], True, preserving_proto_field_name=True), "utf-8")

--- a/test/functional_tests/script10_claim_timeout_all.sh
+++ b/test/functional_tests/script10_claim_timeout_all.sh
@@ -1,0 +1,38 @@
+
+
+snet service metadata-init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --group-name group0 --fixed-price 0.0001 --endpoints 8.8.8.8:2020 9.8.9.8:8080
+snet service metadata-add-group group1 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18
+snet service metadata-add-endpoints  8.8.8.8:22   1.2.3.4:8080 --group-name group1
+
+snet service metadata-add-group group2 0x32267d505B1901236508DcDa64C1D0d5B9DF639a
+snet service metadata-add-endpoints  8.8.8.8:2   1.2.3.4:800 --group-name group2
+
+snet organization create testo --org-id testo -y -q
+snet service publish testo tests -y -q
+
+EXPIRATION0=$((`snet channel block-number` - 1))
+EXPIRATION1=$((`snet channel block-number` - 1))
+EXPIRATION2=$((`snet channel block-number` + 100000))
+
+snet account deposit 100 -y -q
+
+
+assert_balance () {
+MPE_BALANCE=$(snet account balance |grep MPE)
+test ${MPE_BALANCE##*:} = $1
+}
+
+
+# should file because group_name has not been specified
+snet channel open-init testo tests 1 $EXPIRATION0 -yq && exit 1 || echo "fail as expected"
+
+snet channel open-init testo tests 0.1 $EXPIRATION0 -yq --group-name group0
+snet channel open-init testo tests 1   $EXPIRATION1 -yq --group-name group1
+snet channel open-init testo tests 10  $EXPIRATION2 -yq --group-name group2
+
+assert_balance 88.9
+
+# should claim channels 0 and 1, but not 2
+snet channel claim-timeout-all -y
+assert_balance 90
+

--- a/test/functional_tests/script11_update_metadata.sh
+++ b/test/functional_tests/script11_update_metadata.sh
@@ -1,0 +1,48 @@
+
+# simple case of one group
+snet service metadata-init ./service_spec1/ ExampleService 0x52653A9091b5d5021bed06c5118D24b23620c529  --fixed-price 0.0001 --endpoints 8.8.8.8:2020
+snet organization create testo --org-id testo -y -q
+snet service publish testo tests -y -q
+
+# change group_id
+
+snet service metadata-init ./service_spec1/ ExampleService 0x52653A9091b5d5021bed06c5118D24b23620c529  --fixed-price 0.0001 --endpoints 8.8.8.8:2020 --metadata-file service_metadata2.json
+
+snet service update-metadata testo tests --metadata-file service_metadata2.json -yq && exit 1 || echo "fail as expected"
+snet service update-metadata testo tests --metadata-file service_metadata2.json -yq --force
+
+#change payment_address
+cat service_metadata2.json | jq '.groups[0].payment_address = "0xc7973537517BfDeA79EE11Fa2D52584241a34dF2"' > service_metadata3.json
+snet service update-metadata testo tests --metadata-file service_metadata3.json -yq && exit 1 || echo "fail as expected"
+snet service update-metadata testo tests --metadata-file service_metadata3.json -yq --force
+
+
+# case with several groups
+snet service metadata-init ./service_spec1/ ExampleService 0x42A605c07EdE0E1f648aB054775D6D4E38496144  --group-name group0 --fixed-price 0.0001 --endpoints 8.8.8.8:2020 9.8.9.8:8080
+snet service metadata-add-group group1 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18
+snet service metadata-add-endpoints  8.8.8.8:22   1.2.3.4:8080 --group-name group1
+
+snet service metadata-add-group group2 0x32267d505B1901236508DcDa64C1D0d5B9DF639a
+snet service metadata-add-endpoints  8.8.8.8:2   1.2.3.4:800 --group-name group2
+
+# this should be fine because we've completly removed default_group
+snet service update-metadata testo tests -yq
+
+# change group_id
+cat service_metadata.json | jq '.groups[1].group_id = "B5r64fQiiB5kvkWZDo7lXmo4i8y0chUvob5/CmfqoP4="' > service_metadata2.json
+mv -f service_metadata2.json service_metadata.json
+
+snet service update-metadata testo tests -yq && exit 1 || echo "fail as expected"
+snet service update-metadata testo tests -yq --force
+
+
+#change payment_address
+cat service_metadata.json | jq '.groups[1].payment_address = "0xc7973537517BfDeA79EE11Fa2D52584241a34dF2"' > service_metadata2.json
+mv -f service_metadata2.json service_metadata.json
+
+snet service update-metadata testo tests -yq && exit 1 || echo "fail as expected"
+snet service update-metadata testo tests -yq --force
+
+snet service print-metadata  testo tests > service_metadata3.json
+
+cmp <(jq -S . service_metadata.json) <(jq -S . service_metadata3.json)

--- a/test/functional_tests/script12_extend_add_for_service.sh
+++ b/test/functional_tests/script12_extend_add_for_service.sh
@@ -1,0 +1,15 @@
+
+snet service metadata-init ./service_spec1/ ExampleService 0x52653A9091b5d5021bed06c5118D24b23620c529  --fixed-price 0.0001 --endpoints 8.8.8.8:2020
+
+snet organization create testo --org-id testo -y -q
+snet service publish testo tests -y -q
+
+snet account deposit 100000000 -yq
+# should file because group_name has not been specified
+snet channel open-init testo tests 123.123 1 -yq 
+
+snet channel print-initialized | grep 123.223 && exit 1 || echo "fail as expected"
+
+snet channel extend-add-for-service testo tests --amount 0.1 --expiration 314 -yq
+snet channel print-initialized | grep 123.223
+

--- a/test/functional_tests/script3_without_addresses.sh
+++ b/test/functional_tests/script3_without_addresses.sh
@@ -47,16 +47,16 @@ snet account balance --snt 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c
 snet account deposit 12345 -y -q --snt 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet account transfer 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18 42 -y -q --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet account withdraw 1 -y -q --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
-snet channel open-init-metadata 42 1 --group-name group1 -y  -q --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet channel open-init-metadata testo testsm 42 1 --group-name group1 -y  -q --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e --registry 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet channel claim-timeout 0 -y -q  --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet channel extend-add 0 --expiration 10000 --amount 42 -y  -q  --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet channel open-init  testo tests 1 1000000  --group-name group2 -y -q  --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e --registry 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
-snet channel print-initialized --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet channel print-initialized --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e --registry 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet channel print-all-filter-sender --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 rm -rf ~/.snet/mpe_client/
-snet channel init-metadata 0 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet channel init-metadata testo tests 0 --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e --registry 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet channel init testo tests 1  --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e --registry 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
-snet channel print-initialized --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
+snet channel print-initialized --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e --registry 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet channel print-all-filter-sender --mpe 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e
 snet service delete testo tests -y -q --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet organization list-services testo --registry-at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2

--- a/test/functional_tests/script9_treasurer.sh
+++ b/test/functional_tests/script9_treasurer.sh
@@ -37,22 +37,22 @@ snet client call-lowlevel testo tests0 0 0 10000 classify {}
 snet client call-lowlevel testo tests0 0 1 20000 classify {} && exit 1 || echo "fail as expected"
 # should fail because amount is incorect
 snet client call-lowlevel testo tests0 0 0 10000 classify {} && exit 1 || echo "fail as expected"
-snet client call testo tests1 classify {} --save-response response.pb  --channel-id 1 --endpoint http://127.0.0.1:50051
-snet client call testo tests1 classify {} --save-field binary_field out.bin  --channel-id 2 --endpoint http://localhost:50051
-snet client call testo tests1 classify {} --save-field predictions out.txt --channel-id 2
+snet client call testo tests1 classify {} --save-response response.pb  --channel-id 1 --endpoint http://127.0.0.1:50051 -y
+snet client call testo tests1 classify {} --save-field binary_field out.bin  --channel-id 2 --endpoint http://localhost:50051 -y
+snet client call testo tests1 classify {} --save-field predictions out.txt --channel-id 2 -y
 rm -f response.pb out.bin out.txt
 snet treasurer claim-all --endpoint 127.0.0.1:50051  --wallet-index 9 -yq
 snet treasurer claim-all --endpoint 127.0.0.1:50051  --wallet-index 9 -yq
 assert_balance 0.0004
-snet client call testo tests0 classify {}
-snet client call testo tests0 classify {}
+snet client call testo tests0 classify {} -y
+snet client call testo tests0 classify {} -y
 snet client  get-channel-state 0 http://localhost:50051
 snet client  get-channel-state 1 http://127.0.0.1:50051
 
 # low level equivalent to "snet client call testo tests1 classify {} --channel-id 1"
 snet client call-lowlevel testo tests1 1 1 10000 classify {}
 
-snet client call testo tests1 classify {} --channel-id 2
+snet client call testo tests1 classify {} --channel-id 2 -y
 
 #only channel 0 should be claimed
 snet treasurer claim-expired --expiration-threshold 1000 --endpoint 127.0.0.1:50051  --wallet-index 9 -yq
@@ -60,17 +60,17 @@ assert_balance 0.0006
 snet treasurer claim 1 2 --endpoint 127.0.0.1:50051  --wallet-index 9 -yq
 assert_balance 0.0008
 
-snet client call testo tests0 classify {}
-snet client call testo tests0 classify {} --channel-id 0
-snet client call testo tests1 classify {} --channel-id 1
-snet client call testo tests1 classify {} --channel-id 2
+snet client call testo tests0 classify {} --yes
+snet client call testo tests0 classify {} --channel-id 0 -y
+snet client call testo tests1 classify {} --channel-id 1 -y
+snet client call testo tests1 classify {} --channel-id 2 -y
 
 # we will start claim of all channels but will not write then to blockchain
 echo n | snet treasurer claim-all --endpoint 127.0.0.1:50051  --wallet-index 9 && exit 1 || echo "fail as expected"
 assert_balance 0.0008
 
-snet client call testo tests1 classify {} --channel-id 1
-snet client call testo tests1 classify {} --channel-id 2
+snet client call testo tests1 classify {} --channel-id 1 -y
+snet client call testo tests1 classify {} --channel-id 2 -y
 
 # and now we should claim everything (including pending payments)
 snet treasurer claim-all --endpoint 127.0.0.1:50051  --wallet-index 9 -yq

--- a/test/functional_tests/script9_treasurer.sh
+++ b/test/functional_tests/script9_treasurer.sh
@@ -60,7 +60,7 @@ assert_balance 0.0006
 snet treasurer claim 1 2 --endpoint 127.0.0.1:50051  --wallet-index 9 -yq
 assert_balance 0.0008
 
-snet client call testo tests0 classify {} --yes
+echo y | snet client call testo tests0 classify {}
 snet client call testo tests0 classify {} --channel-id 0 -y
 snet client call testo tests1 classify {} --channel-id 1 -y
 snet client call testo tests1 classify {} --channel-id 2 -y

--- a/test/functional_tests/script9_treasurer.sh
+++ b/test/functional_tests/script9_treasurer.sh
@@ -10,6 +10,7 @@ cd ..
 snet account deposit 12345 -y -q
 
 # service provider has --wallet-index==9 (0x52653A9091b5d5021bed06c5118D24b23620c529)
+# make two endpoints (both are actually valid)
 snet service metadata-init ./service_spec1/ ExampleService 0x52653A9091b5d5021bed06c5118D24b23620c529 --fixed-price 0.0001 --endpoints 127.0.0.1:50051
 
 
@@ -22,12 +23,22 @@ EXPIRATION0=$((`snet channel block-number` + 100))
 EXPIRATION1=$((`snet channel block-number` + 100000))
 EXPIRATION2=$((`snet channel block-number` + 100000))
 snet channel open-init-metadata testo tests0 1 $EXPIRATION0 -yq
+
+# add second endpoint to metadata (in order to test case with two endpoints in metadata)
+snet service metadata-add-endpoints localhost:50051
+
+# formally we will have two open chanels (channnel_id = 1,2) for the same service (testo/tests1)
 snet channel open-init-metadata testo tests1 1 $EXPIRATION1 -yq --open-new-anyway
 snet channel open-init-metadata testo tests1 1 $EXPIRATION2 -yq --open-new-anyway
 
-snet client call testo tests0 classify {}
+#low level equivalent to "snet client call testo tests0 classify {}"
+snet client call-lowlevel testo tests0 0 0 10000 classify {}
+# should fail because nonce is incorect
+snet client call-lowlevel testo tests0 0 1 20000 classify {} && exit 1 || echo "fail as expected"
+# should fail because amount is incorect
+snet client call-lowlevel testo tests0 0 0 10000 classify {} && exit 1 || echo "fail as expected"
 snet client call testo tests1 classify {} --save-response response.pb  --channel-id 1 --endpoint http://127.0.0.1:50051
-snet client call testo tests1 classify {} --save-field binary_field out.bin  --channel-id 2
+snet client call testo tests1 classify {} --save-field binary_field out.bin  --channel-id 2 --endpoint http://localhost:50051
 snet client call testo tests1 classify {} --save-field predictions out.txt --channel-id 2
 rm -f response.pb out.bin out.txt
 snet treasurer claim-all --endpoint 127.0.0.1:50051  --wallet-index 9 -yq
@@ -35,7 +46,12 @@ snet treasurer claim-all --endpoint 127.0.0.1:50051  --wallet-index 9 -yq
 assert_balance 0.0004
 snet client call testo tests0 classify {}
 snet client call testo tests0 classify {}
-snet client call testo tests1 classify {} --channel-id 1
+snet client  get-channel-state 0 http://localhost:50051
+snet client  get-channel-state 1 http://127.0.0.1:50051
+
+# low level equivalent to "snet client call testo tests1 classify {} --channel-id 1"
+snet client call-lowlevel testo tests1 1 1 10000 classify {}
+
 snet client call testo tests1 classify {} --channel-id 2
 
 #only channel 0 should be claimed

--- a/test/functional_tests/script9_treasurer.sh
+++ b/test/functional_tests/script9_treasurer.sh
@@ -21,22 +21,22 @@ test ${MPE_BALANCE##*:} = $1
 EXPIRATION0=$((`snet channel block-number` + 100))
 EXPIRATION1=$((`snet channel block-number` + 100000))
 EXPIRATION2=$((`snet channel block-number` + 100000))
-snet channel open-init-metadata 1 $EXPIRATION0 -yq
-snet channel open-init-metadata 1 $EXPIRATION1 -yq
-snet channel open-init-metadata 1 $EXPIRATION2 -yq
+snet channel open-init-metadata testo tests0 1 $EXPIRATION0 -yq
+snet channel open-init-metadata testo tests1 1 $EXPIRATION1 -yq --open-new-anyway
+snet channel open-init-metadata testo tests1 1 $EXPIRATION2 -yq --open-new-anyway
 
-snet client call 0 0.0001 http://127.0.0.1:50051 classify {}
-snet client call 0 0.0001 https://127.0.0.1:50051 classify {} --save-response response.pb
-snet client call 1 0.0001 127.0.0.1:50051 classify {} --save-field binary_field out.bin
-snet client call 2 0.0001 127.0.0.1:50051 classify {} --save-field predictions out.txt
+snet client call testo tests0 classify {}
+snet client call testo tests1 classify {} --save-response response.pb  --channel-id 1 --endpoint http://127.0.0.1:50051
+snet client call testo tests1 classify {} --save-field binary_field out.bin  --channel-id 2
+snet client call testo tests1 classify {} --save-field predictions out.txt --channel-id 2
 rm -f response.pb out.bin out.txt
 snet treasurer claim-all --endpoint 127.0.0.1:50051  --wallet-index 9 -yq
 snet treasurer claim-all --endpoint 127.0.0.1:50051  --wallet-index 9 -yq
 assert_balance 0.0004
-snet client call 0 0.0001 127.0.0.1:50051 classify {}
-snet client call 0 0.0001 127.0.0.1:50051 classify {}
-snet client call 1 0.0001 127.0.0.1:50051 classify {}
-snet client call 2 0.0001 127.0.0.1:50051 classify {}
+snet client call testo tests0 classify {}
+snet client call testo tests0 classify {}
+snet client call testo tests1 classify {} --channel-id 1
+snet client call testo tests1 classify {} --channel-id 2
 
 #only channel 0 should be claimed
 snet treasurer claim-expired --expiration-threshold 1000 --endpoint 127.0.0.1:50051  --wallet-index 9 -yq
@@ -44,20 +44,20 @@ assert_balance 0.0006
 snet treasurer claim 1 2 --endpoint 127.0.0.1:50051  --wallet-index 9 -yq
 assert_balance 0.0008
 
-snet client call 0 0.0001 127.0.0.1:50051 classify {}
-snet client call 0 0.0001 127.0.0.1:50051 classify {}
-snet client call 1 0.0001 127.0.0.1:50051 classify {}
-snet client call 2 0.0001 127.0.0.1:50051 classify {}
+snet client call testo tests0 classify {}
+snet client call testo tests0 classify {} --channel-id 0
+snet client call testo tests1 classify {} --channel-id 1
+snet client call testo tests1 classify {} --channel-id 2
 
 # we will start claim of all channels but will not write then to blockchain
 echo n | snet treasurer claim-all --endpoint 127.0.0.1:50051  --wallet-index 9 && exit 1 || echo "fail as expected"
 assert_balance 0.0008
 
-snet client call 1 0.0001 127.0.0.1:50051 classify {}
-snet client call 2 0.0001 127.0.0.1:50051 classify {}
+snet client call testo tests1 classify {} --channel-id 1
+snet client call testo tests1 classify {} --channel-id 2
 
 # and now we should claim everything (including pending payments)
-snet treasurer claim-all --endpoint 127.0.0.1:50051  --wallet-index 9 -yq 
+snet treasurer claim-all --endpoint 127.0.0.1:50051  --wallet-index 9 -yq
 assert_balance 0.0014
 
 kill $DAEMON

--- a/test/functional_tests/simple_daemon/test_simple_daemon.py
+++ b/test/functional_tests/simple_daemon/test_simple_daemon.py
@@ -9,7 +9,7 @@ from snet_cli.config import Config
 compile_proto("../service_spec1", ".", proto_file = "ExampleService.proto")
 compile_proto("../../../snet_cli/resources/proto/", ".", proto_file = "state_service.proto")
 compile_proto("../../../snet_cli/resources/proto/", ".", proto_file = "control_service.proto")
-
+PRICE = 10000
 
 import grpc
 
@@ -40,37 +40,51 @@ def remove_already_claimed_payments():
         print("remove payment for channel %i from payments_in_progress"%channel_id)
         del payments_in_progress[channel_id]
 
+def get_current_channel_state(channel_id):
+    if (channel_id in payments_unclaimed):
+        nonce         = payments_unclaimed[channel_id]["nonce"]
+        amount        = payments_unclaimed[channel_id]["amount"]
+        signature     = payments_unclaimed[channel_id]["signature"]
+    else:
+        nonce  = 0
+        amount = 0
+        signature = "".encode("ascii")
+    return nonce, amount, signature
 
-class ExampleService(ExampleService_pb2_grpc.ExampleServiceServicer):    
+
+class ExampleService(ExampleService_pb2_grpc.ExampleServiceServicer):
     def classify(self, request, context):
         metadata = dict(context.invocation_metadata())
         channel_id = int(metadata["snet-payment-channel-id"])
         nonce      = int(metadata["snet-payment-channel-nonce"])
         amount     = int(metadata["snet-payment-channel-amount"])
-        signature  = metadata["snet-payment-channel-signature-bin"]        
+        signature  = metadata["snet-payment-channel-signature-bin"]
         payment = {"channel_id": channel_id, "nonce": nonce, "amount": amount, "signature": signature}
+
+        # we check nonce and amount, but we don't check signature
+        current_nonce, current_signed_amount, _ = get_current_channel_state(channel_id)
+
+        if (current_nonce != nonce):
+            raise Exception("nonce is incorrect")
+
+        if (current_signed_amount + PRICE != amount):
+            raise Exception("Signed amount is incorrect %i vs %i"%(current_signed_amount + PRICE, amount))
+
         payments_unclaimed[channel_id] = payment
         return ExampleService_pb2.ClassifyResponse(predictions=["prediction1", "prediction2" ], confidences=[0.42, 0.43], binary_field = int(12345**5).to_bytes(10,byteorder='big'))
 
 
-class PaymentChannelStateService(state_service_pb2_grpc.PaymentChannelStateServiceServicer):    
+class PaymentChannelStateService(state_service_pb2_grpc.PaymentChannelStateServiceServicer):
     def GetChannelState(self, request, context):
         channel_id = int.from_bytes(request.channel_id, byteorder='big')
-        if (channel_id in payments_unclaimed):
-            nonce         = payments_unclaimed[channel_id]["nonce"]
-            amount = payments_unclaimed[channel_id]["amount"]
-            signature     = payments_unclaimed[channel_id]["signature"]
-        else:
-            nonce  = 0
-            amount = 0
-            signature = "".encode("ascii")
-        return state_service_pb2.ChannelStateReply(current_nonce         = web3.Web3.toBytes(nonce), 
-                                                   current_signed_amount = web3.Web3.toBytes(amount), 
+        nonce, amount, signature = get_current_channel_state(channel_id)
+        return state_service_pb2.ChannelStateReply(current_nonce         = web3.Web3.toBytes(nonce),
+                                                   current_signed_amount = web3.Web3.toBytes(amount),
                                                    current_signature     = signature)
 
 
-class ProviderControlService(control_service_pb2_grpc.ProviderControlServiceServicer):    
-    def GetListUnclaimed(self, request, context):        
+class ProviderControlService(control_service_pb2_grpc.ProviderControlServiceServicer):
+    def GetListUnclaimed(self, request, context):
         payments = []
         for channel_id in payments_unclaimed:
             nonce  = payments_unclaimed[channel_id]["nonce"]
@@ -82,7 +96,7 @@ class ProviderControlService(control_service_pb2_grpc.ProviderControlServiceServ
             payments.append(payment)
         return control_service_pb2.PaymentsListReply(payments = payments)
 
-    def GetListInProgress(self, request, context):        
+    def GetListInProgress(self, request, context):
         remove_already_claimed_payments()
 
         payments = []
@@ -96,21 +110,21 @@ class ProviderControlService(control_service_pb2_grpc.ProviderControlServiceServ
             payments.append(payment)
         return control_service_pb2.PaymentsListReply(payments = payments)
 
-    def StartClaim(self, request, context):        
+    def StartClaim(self, request, context):
         remove_already_claimed_payments()
 
         channel_id = int.from_bytes(request.channel_id, byteorder='big')
-        
+
         if (channel_id not in payments_unclaimed):
             raise Exception("channel_id not in payments_unclaimed")
-        
+
         p = payments_unclaimed[channel_id]
         nonce     = p["nonce"]
         amount    = p["amount"]
-        signature = p["signature"] 
+        signature = p["signature"]
         payments_in_progress[channel_id] = p
         payments_unclaimed[channel_id] = {"nonce" : nonce + 1, "amount" : 0, "signature" : bytes(0)}
-        
+
         return control_service_pb2.PaymentReply(
                         channel_id    = web3.Web3.toBytes(channel_id),
                         channel_nonce = web3.Web3.toBytes(nonce),
@@ -130,8 +144,8 @@ def serve():
             time.sleep(60*60*24)
     except KeyboardInterrupt:
         server.stop(0)
-            
-            
+
+
 if __name__ == '__main__':
     serve()
-                                                                        
+


### PR DESCRIPTION
This PR solves #201 and #208. It adds proper support for secure channels (https) and it significantly simplifies the life for users by hiding channel_id (and endpoints).

Example of workflow:
```
snet network ropsten

# open new channel only if you haven't done it already 
# It will not open new channel if you already have one!
snet channel open-init DappTesOrganization DappTesthttpsService 0.00001 +8days

# add funds if needed (for service which was opened for specific service)
snet channel extend-add-for-service DappTesOrganization DappTesthttpsService --amount 0.00001 --expiration +8days

# print list of initialized channels 
snet channel print-initialized

# make a call (you can use -y to remove price warning)
snet client call DappTesOrganization DappTesthttpsService mul '{"a":12,"b":7}'

# try claim timeout for ALL your channels (channels which have your as a sender)
snet channel claim-timeout-all
```

This PR does the following:
- change directories struct in ```~/.snet/mpe_client``` in order to make it more similar to @vforvalerio87 SDK.  This new directories structure allows hiding channel_id from user.
     - Store compiled protobuf for service with ```<org_id>``` and ```<service_id>``` in ```~/.snet/mpe_client/<mpe_address>_<registry_address>/<org_id>/<service_id>/service```
    - Store initialized channels for this service in : ```~/.snet/mpe_client/<mpe_address>_<registry_address>/<org_id>/<service_id>/channels```
- By default ```snet channel open-init``` will not open new channel if old channel for this service already exists. It will simply initialize existed channel.
- ```snet client call``` has the following positional parameters: ```<org_id> <service_id> <method> <params>```. User will need to manually specify channel_id only in case of multiply channels initialized for the same service (which, by default, is prevented  in ```snet channel open-init```).
- make ```snet client call``` more faster by removing unnecessary blockchain call.
- Remove price from list of obligatory parameter in ```snet client call```. Instead, as was  proposed by @arturgontijo, we have interactive confirmation. We have possibility to skip this confirmation by ```--yes/-y```.
- Change output of ```snet channel print-initialized``` to include org_id and service_id and remove unnecessary group_id
- rename ```snet channel print-initialized-filter-group``` to ```snet channel print-initialized-filter-service``` because now it will print all initialized channels for whole service (not only for the specifc group). Change output to more informative similarly to ```snet channel print-initialized```.
- Add ```snet channel claim-timeout-all``` function which check ALL channels for the given identity and claim timeout for all expired channels.
- Add ```snet channel extend-add-for-service``` function which add funds and extend expiration data for the channel which was opened for specific channel
- (small change) In ```snet service update-metadata``` check that group_id or payment_address haven't been changed. We have possibility to force this change by ```--force```
- Add tests for all new functions and for some old ones (```snet client call-lowlevel```, ```snet client get-channel-state```)