### PR TITLE
Check for service update (change in metadataURI) at each call. Remove neccessity for service/channel initialization in simple cases.

### DIFF
--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -444,7 +444,7 @@ def add_p_open_channel_basic(p):
     add_p_from_block(p)
 
 def add_p_from_block(p):
-        p.add_argument("--from-block", type=int, default=0, help="Start searching from this block")
+        p.add_argument("--from-block", type=int, default=0, help="Start searching from this block (for channel searching)")
 
 def add_mpe_channel_options(parser):
     parser.set_defaults(cmd=MPEChannelCommand)
@@ -507,6 +507,7 @@ def add_mpe_channel_options(parser):
     add_p_set_for_extend_add(p)
     add_p_group_name(p)
     add_p_channel_id_opt(p)
+    add_p_from_block(p)
 
     p = subparsers.add_parser("block-number", help="Print the last ethereum block number")
     p.set_defaults(fn="print_block_number")
@@ -599,7 +600,9 @@ def add_mpe_client_options(parser):
     add_p_org_id_service_id(p)
     add_p_set1_for_call(p)
     add_p_channel_id_opt(p)
+    add_p_from_block(p)
     p.add_argument("--yes", "-y", action="store_true", help="skip interactive confirmation of call price", default=False)
+    p.add_argument("--skip-update-check", action="store_true", help="skip check for service update", default=False)
 
 
     p = subparsers.add_parser("call-lowlevel", help="Low level function for calling the server. Service should be already initialized.")

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -247,7 +247,7 @@ def add_organization_options(parser):
     add_p_org_id(p)
     add_contract_identity_arguments(p, [("registry", "registry_at")])
     add_eth_call_arguments(p)
-    
+
     p = subparsers.add_parser("change-name", help="Change Organization's name")
     p.set_defaults(fn="change_name")
     add_p_org_id(p)
@@ -415,6 +415,10 @@ def add_mpe_account_options(parser):
 def add_p_channel_id(p):
     # int is ok here because in python3 int is unlimited
     p.add_argument("channel_id", type=int, help="channel_id")
+
+def add_p_channel_id_opt(p):
+    p.add_argument("--channel-id", type=int, help="channel_id (only in case of multiply initialized channels for the same payment group)")
+
 def add_p_endpoint(p):
     p.add_argument("endpoint",             help="service endpoint")
 
@@ -501,6 +505,8 @@ def add_mpe_channel_options(parser):
     p.set_defaults(fn="channel_extend_and_add_funds_for_service")
     add_p_service_in_registry(p)
     add_p_set_for_extend_add(p)
+    add_p_group_name(p)
+    add_p_channel_id_opt(p)
 
     p = subparsers.add_parser("block-number", help="Print the last ethereum block number")
     p.set_defaults(fn="print_block_number")
@@ -592,7 +598,7 @@ def add_mpe_client_options(parser):
     p.set_defaults(fn="call_server_statelessly")
     add_p_org_id_service_id(p)
     add_p_set1_for_call(p)
-    p.add_argument("--channel-id", type=int, help="channel_id (only in case of multiply initialized channels for the same payment group)")
+    add_p_channel_id_opt(p)
     p.add_argument("--yes", "-y", action="store_true", help="skip interactive confirmation of call price", default=False)
 
 
@@ -610,7 +616,7 @@ def add_mpe_client_options(parser):
     add_p_channel_id(p)
     add_p_endpoint(p)
     add_eth_call_arguments(p)
- 
+
 
 def add_mpe_service_options(parser):
     parser.set_defaults(cmd=MPEServiceCommand)

--- a/snet_cli/mpe_client_command.py
+++ b/snet_cli/mpe_client_command.py
@@ -111,8 +111,7 @@ class MPEClientCommand(MPEChannelCommand):
                     ("snet-payment-channel-nonce",         str(nonce)       ),
                     ("snet-payment-channel-amount",        str(amount)      ),
                     ("snet-payment-channel-signature-bin", bytes(signature))]
-        response = call_fn(request, metadata=metadata)
-        return response
+        return call_fn(request, metadata=metadata)
 
     def _deal_with_call_response(self, response):
         if (self.args.save_response):
@@ -238,8 +237,7 @@ class MPEClientCommand(MPEChannelCommand):
         if (not proceed):
             self._error("Cancelled")
 
-        response = self._call_server_via_grpc_channel(grpc_channel, channel_id, server_state["current_nonce"], server_state["current_signed_amount"] + price, params, service_metadata)
-        return response
+        return self._call_server_via_grpc_channel(grpc_channel, channel_id, server_state["current_nonce"], server_state["current_signed_amount"] + price, params, service_metadata)
 
     def call_server_statelessly(self):
         params           = self._get_call_params()

--- a/snet_cli/mpe_service_command.py
+++ b/snet_cli/mpe_service_command.py
@@ -143,11 +143,11 @@ class MPEServiceCommand(BlockchainCommand):
         rez = self.call_contract_command("Registry", "getServiceRegistrationById", params)
         if (rez[0] == False):
             raise Exception("Cannot find Service with id=%s in Organization with id=%s"%(self.args.service_id, self.args.org_id))
-        return rez
+        return {"metadataURI" : rez[2], "tags" : rez[3]}
 
     def _get_service_metadata_from_registry(self):
         rez           = self._get_service_registration()
-        metadata_hash = bytesuri_to_hash(rez[2])
+        metadata_hash = bytesuri_to_hash(rez["metadataURI"])
         metadata      = get_from_ipfs_and_checkhash(self._get_ipfs_client(), metadata_hash)
         metadata      = metadata.decode("utf-8")
         metadata      = mpe_service_metadata_from_json(metadata)
@@ -159,7 +159,7 @@ class MPEServiceCommand(BlockchainCommand):
 
     def print_service_tags_from_registry(self):
         rez  = self._get_service_registration()
-        tags = rez[3]
+        tags = rez["tags"]
         tags = [bytes32_to_str(tag) for tag in tags]
         self._printout(" ".join(tags))
 

--- a/test/functional_tests/script12_extend_add_for_service.sh
+++ b/test/functional_tests/script12_extend_add_for_service.sh
@@ -5,11 +5,44 @@ snet organization create testo --org-id testo -y -q
 snet service publish testo tests -y -q
 
 snet account deposit 100000000 -yq
-# should file because group_name has not been specified
-snet channel open-init testo tests 123.123 1 -yq 
+
+snet channel open-init testo tests 123.123 1 -yq
 
 snet channel print-initialized | grep 123.223 && exit 1 || echo "fail as expected"
 
 snet channel extend-add-for-service testo tests --amount 0.1 --expiration 314 -yq
 snet channel print-initialized | grep 123.223
+
+rm -rf ~/.snet/mpe_client
+snet channel extend-add-for-service testo tests --amount 0.1 --expiration 314 -yq
+snet channel print-initialized | grep 123.323
+
+
+snet channel open-init testo tests 7777.8888 1 -yq --open-new-anyway
+snet channel extend-add-for-service testo tests --amount 0.01 --expiration 314 -yq && exit 1 || echo "fail as expected"
+snet channel extend-add-for-service testo tests --amount 0.01 --expiration 314 -yq --channel-id 1
+snet channel print-initialized | grep 7777.8988
+
+# multiply payment groups case
+snet service metadata-init ./service_spec1/ ExampleService 0x52653A9091b5d5021bed06c5118D24b23620c529  --fixed-price 0.0001 --endpoints 8.8.8.8:2020 --group-name group1
+snet service metadata-add-group group2 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18
+snet service metadata-add-endpoints  8.8.8.8:20202 9.10.9.8:8080 --group-name group2
+
+snet service publish testo tests2 -y -q
+
+snet channel open-init testo tests2 2222.33333 1 -yq --group-name group1
+
+snet channel extend-add-for-service testo tests2 --amount 0.001 --expiration 314 -yq && exit 1 || echo "fail as expected"
+snet channel extend-add-for-service testo tests2 --amount 0.001 --expiration 314 --group-name group1 -yq
+
+snet channel print-initialized | grep 2222.33433
+
+snet channel open-init testo tests2 2222.33333 1 -yq --group-name group2
+snet channel extend-add-for-service testo tests2 --amount 0.0001 --expiration 314 -yq --group-name group2
+snet channel print-initialized | grep 2222.33343
+
+rm -rf ~/.snet/mpe_client
+
+snet channel extend-add-for-service testo tests2 --amount 0.00001 --expiration 314 -yq --group-name group2
+snet channel print-initialized | grep 2222.33344
 

--- a/test/functional_tests/script13_call_reinitialize.sh
+++ b/test/functional_tests/script13_call_reinitialize.sh
@@ -1,0 +1,56 @@
+# script13
+
+# run daemon
+cd simple_daemon
+python test_simple_daemon.py &
+DAEMON=$!
+cd ..
+
+
+
+snet service metadata-init ./service_spec1/ ExampleService 0x52653A9091b5d5021bed06c5118D24b23620c529 --fixed-price 0.0001 --endpoints 127.0.0.1:50051
+snet account deposit 12345 -y -q
+snet organization create testo --org-id testo -y -q
+snet service publish testo tests -y -q
+snet channel open-init testo tests 1 +10days -yq
+
+snet client call testo tests classify {} -y
+
+rm -rf ~/.snet/mpe_client
+
+snet client call testo tests classify {} -y
+snet client call testo tests classify {} -y --skip-update-check
+
+# we will corrupt initialized channel
+rm -rf ~/.snet/mpe_client/*/testo/tests/service/*py
+
+# in the current version snet-cli cannot detect this problem, so it should fail
+# and it is ok, because it shoudn't update service at each call
+snet client call testo tests classify {} -y && exit 1 || echo "fail as expected"
+
+snet service metadata-add-endpoints localhost:50051
+
+# this should still fail because we skip registry check
+snet client call testo tests classify {} -y --skip-update-check && exit 1 || echo "fail as expected"
+
+snet service update-metadata testo tests -yq
+
+# no snet-cli should automatically update service, because metadataURI has changed
+snet client call testo tests classify {} -y
+
+# multiply payment groups case
+# multiply payment groups case
+snet service metadata-init ./service_spec1/ ExampleService 0x52653A9091b5d5021bed06c5118D24b23620c529  --fixed-price 0.0001 --endpoints 127.0.0.1:50051 --group-name group1
+snet service metadata-add-group group2 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18
+snet service metadata-add-endpoints localhost:50051 --group-name group2
+snet service publish testo tests2 -y -q
+snet client call testo tests2 classify {} -y --group-name group2 && exit 1 || echo "fail as expected"
+snet channel open-init testo tests2 1 +10days -yq --group-name group2
+snet client call testo tests2 classify {} -y --group-name group2
+
+
+rm -rf ~/.snet/mpe_client
+
+
+kill $DAEMON
+


### PR DESCRIPTION
This PR fix #164 (however with some performance caveats, because at each call we need to get metadataURI from Registry).

This PR does following:
* We save ```metadataURI``` for each initialized service. At each call we verify that ```metadataURI``` hasn't been changed in Registry and if it happen we update initialized service... A heavy price. If user doesn't want to pay it gladly he can skip this check with ```--skip-update-check```.
* As a bonus ```snet client call``` and ```snet channel extend-add-for-service``` will be able to work without any channel/service initialization (in simple cases of sender=signer). So if you already have a channel then you can run ```snet client call``` (or ```snet channel extend-add-for-service```) directly. snet-cli will automatically initialize service and find and initialize appropriate channel. 
* However you still need manually initialize channel (```snet channel init```) in difficult cases of signer not equal to sender.
* Storage of initialized channels was improved. Old relic of channel directories was removed. 

Example of workflow:
```
# On ropsten
# open new channel to snet/example-service (If you already have you channel, it will not open new one!)
snet channel open-init snet example-service 0.00001 +10days

# make a call
snet client call snet example-service mul '{"a":12,"b":7}'

# if service provider makes any change in service, for example, update endpoint or protobuf files or price then snet-cli will update initialized service on fly
snet client call snet example-service mul '{"a":12,"b":7}'

# If user lost it's configuration snet-cli will reinitialize channel/service automatically

# simulate lost of configuration
# rm -rf ~/.snet/mpe_client   # (uncomment for run :) )
snet client call snet example-service mul '{"a":12,"b":7}'
 
# simulate lost of configuration
# rm -rf ~/.snet/mpe_client   # (uncomment for run :) )
 snet channel  extend-add-for-service snet example-service --amount 0.000001 --expiration +10days
```