### PR TITLE
Simple call stub generator for calling 'snet client call' from a python code

### DIFF
--- a/snet_cli/call_stub_generator.py
+++ b/snet_cli/call_stub_generator.py
@@ -5,4 +5,9 @@ from snet_cli.utils import DefaultAttributeObject
 def call_stub_generator(org_id, service_id, method, **kwargs):
     conf = Config()
     args = DefaultAttributeObject(org_id = org_id, service_id = service_id, method = method, yes = True, **kwargs)
-    return MPEClientCommand(conf, args)
+    class Stub:
+        def __call__(self, params):
+            return self.client.call_server_statelessly_with_params(params)
+    stub = Stub()
+    stub.client = MPEClientCommand(conf, args)
+    return stub

--- a/snet_cli/call_stub_generator.py
+++ b/snet_cli/call_stub_generator.py
@@ -1,0 +1,8 @@
+from snet_cli.mpe_client_command import MPEClientCommand
+from snet_cli.config import Config
+from snet_cli.utils import DefaultAttributeObject
+
+def call_stub_generator(org_id, service_id, method, **kwargs):
+    conf = Config()
+    args = DefaultAttributeObject(org_id = org_id, service_id = service_id, method = method, yes = True, **kwargs)
+    return MPEClientCommand(conf, args)

--- a/test/functional_tests/script14_stub_tests.py
+++ b/test/functional_tests/script14_stub_tests.py
@@ -1,0 +1,6 @@
+from snet_cli.call_stub_generator import call_stub_generator
+
+stub = call_stub_generator("testo", "tests", "classify")
+
+rez = stub.call_server_statelessly_with_params({})
+print(rez)

--- a/test/functional_tests/script14_stub_tests.py
+++ b/test/functional_tests/script14_stub_tests.py
@@ -2,5 +2,5 @@ from snet_cli.call_stub_generator import call_stub_generator
 
 stub = call_stub_generator("testo", "tests", "classify")
 
-rez = stub.call_server_statelessly_with_params({})
+rez = stub({})
 print(rez)

--- a/test/functional_tests/script14_stub_tests.sh
+++ b/test/functional_tests/script14_stub_tests.sh
@@ -1,0 +1,18 @@
+# script13
+
+# run daemon
+cd simple_daemon
+python test_simple_daemon.py &
+DAEMON=$!
+cd ..
+
+
+snet service metadata-init ./service_spec1/ ExampleService 0x52653A9091b5d5021bed06c5118D24b23620c529 --fixed-price 0.0001 --endpoints 127.0.0.1:50051
+snet account deposit 12345 -y -q
+snet organization create testo --org-id testo -y -q
+snet service publish testo tests -y -q
+snet channel open-init testo tests 1 +10days -yq
+
+python script14_stub_tests.py
+
+kill $DAEMON


### PR DESCRIPTION
This PR partly deals with https://github.com/singnet/snet-cli/issues/29 (for python).
It adds simple call stub generator for calling services from python, using snet-cli infrastructure.

For example you can write the following code for calling ```snet/example-service```

```python
from snet_cli.call_stub_generator import call_stub_generator

stub = call_stub_generator("snet", "example-service", "add")

# parameters should be a dictionary (not a json!), so it can have binary fields.
params = {"a":1, "b":2}

rez = stub.call_server_statelessly_with_params(params)
print(rez)
``` 
- Parameters are passed in form of a dictionary. It is relative easy to pass parameters directly in Request format, but I don't think it is necessary .  
- It should be noted that this PR is independent from  #218 but after #218 you will be able to run this python code without any channel initialization in snet-cli (but of course only if you already have a funded channel). 

