### PR TITLE
Autocompletion of snet commands with TAB (fix for #108)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ You should have python with version >= 3.6.5 and pip installed.
 Additionally you should install the following packages:
 
 * libudev
-* libusb 1.0
-* python-argcomplete
+* libusb 1.0 
 
 If you use Ubuntu (or any Linux distribution with APT package support) you should do the following:
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,28 @@ Additionally you should install the following packages:
 
 * libudev
 * libusb 1.0
+* python-argcomplete
 
 If you use Ubuntu (or any Linux distribution with APT package support) you should do the following:
 
 ```bash
 sudo apt-get install libudev-dev libusb-1.0-0-dev
 ```
+
+If you want to enable auto completion of snet commands, you should install the following package
+* python-argcomplete
+
+On ubuntu (or any Linux distribution with APT package support), you should do the following
+
+```bash
+sudo apt install python-argcomplete
+```
+After the package is installed, activate autocomplete by using 
+
+```bash
+sudo activate-global-python-argcomplete
+```
+Note: Changes will not take effect until shell is restarted.
 
 #### Install snet-cli using pip
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,15 @@ If you use Ubuntu (or any Linux distribution with APT package support) you shoul
 sudo apt-get install libudev-dev libusb-1.0-0-dev
 ```
 
-If you want to enable auto completion of snet commands, you should install the following package
+#### Install snet-cli using pip
+
+```bash
+$ pip3 install snet-cli
+```
+
+
+#### Enabling commands autocomplete
+If you want to enable auto completion of commands, you should install the following package
 * python-argcomplete
 
 On ubuntu (or any Linux distribution with APT package support), you should do the following
@@ -34,17 +42,22 @@ On ubuntu (or any Linux distribution with APT package support), you should do th
 ```bash
 sudo apt install python-argcomplete
 ```
-After the package is installed, activate autocomplete by using 
+After the package is installed, activate autocomplete 
+
+##### for all python commands (which includes snet commands as well) 
 
 ```bash
 sudo activate-global-python-argcomplete
 ```
 Note: Changes will not take effect until shell is restarted.
 
-#### Install snet-cli using pip
-
+##### only for snet commands, then you should do the following
 ```bash
-$ pip3 install snet-cli
+echo 'eval "$(register-python-argcomplete snet)"' >> ~/.bashrc
+```
+then
+```bash
+source ~/.bashrc
 ```
 
 ### Commands

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,8 @@ setup(
         'pillow>=3.4.0',  # _vendor/ledgerblue
         'python-u2flib-host>=3.0.2',  # _vendor/ledgerblue
         'pymultihash==0.8.2',
-        'base58==1.0.2'
+        'base58==1.0.2',
+        'argcomplete>=1.9.4'
     ],
     cmdclass={
         'develop': develop,

--- a/snet_cli/__init__.py
+++ b/snet_cli/__init__.py
@@ -1,7 +1,11 @@
+#!/usr/bin/env python
+# PYTHON_ARGCOMPLETE_OK
+
 import sys
 
 from snet_cli import arguments
 from snet_cli.config import Config
+import argcomplete
 
 __version__ = "0.2.10"
 
@@ -11,6 +15,7 @@ def main():
         argv = sys.argv[1:]
         conf   = Config()
         parser = arguments.get_root_parser(conf)
+        argcomplete.autocomplete(parser)
 
         try:
             args = parser.parse_args(argv)


### PR DESCRIPTION
This change enables auto completion of snet commands with pressing of TAB key after we enter 3 char. We are using the argcomplete package, since our commands leverage argparse.

one key observation with argcomplete is, sometimes the auto completion registration scripts may not come with package installation. To avoid the issue, we can install that package as a prerequisite (steps are added to readme)

@raamb @astroseger can you please review the changes 