### PR TITLE
Gas price strategies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     install_requires=[
         'grpcio-tools==1.17.1',
         'jsonrpcclient==2.5.2',
-        'web3==4.2.1',
+        'web3==4.8.3',
         'mnemonic==0.18',
         'pycoin>=0.80',
         'ecdsa==0.13',
@@ -56,7 +56,7 @@ setup(
         'hidapi>=0.7.99',  # _vendor/ledgerblue
         'protobuf>=2.6.1',  # _vendor/ledgerblue
         'pycryptodome>=3.6.6',  # _vendor/ledgerblue
-        'eth-hash==0.1.4',  # the latest eth-hash v0.2.0 requires pycryptodome>=3.6.6,<4
+        'eth-hash>=0.2.0',  # the latest eth-hash v0.2.0 requires pycryptodome>=3.6.6,<4
         'future==0.16.0',  # _vendor/ledgerblue
         'ecpy>=0.8.1',  # _vendor/ledgerblue
         'pillow>=3.4.0',  # _vendor/ledgerblue

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -148,7 +148,7 @@ def add_network_options(parser, config):
     p.set_defaults(fn="create")
     p.add_argument("network_name", help="name of network to create")
     p.add_argument("eth_rpc_endpoint", help="ethereum rpc endpoint")
-    p.add_argument("--default-gas-price", default=1000000000, type=int, help="default gas price for this network (in wei), default is 1000000000")
+    p.add_argument("--default-gas-price", default="medium", help="default gas price (in wei) or gas price strategy ('fast' ~1min, 'medium' ~5min or 'slow' ~60min), default is 'medium'")
     p.add_argument("--skip-check", action="store_true", help="skip check that eth_rpc_endpoint is valid")
 
 
@@ -331,8 +331,7 @@ def add_eth_call_arguments(parser):
 
 def add_transaction_arguments(parser):
     transaction_g = parser.add_argument_group(title="transaction arguments")
-    transaction_g.add_argument("--gas-price", type=int,
-                               help="ethereum gas price for transaction (defaults to session.default_gas_price)")
+    transaction_g.add_argument("--gas-price", help="ethereum gas price in Wei or time based gas price strategy ('fast' ~1min, 'medium' ~5min or 'slow' ~60min)  (defaults to session.default_gas_price)")
     transaction_g.add_argument("--wallet-index", type=int,
                                help="wallet index of account to use for signing (defaults to session.identity.default_wallet_index)")
     transaction_g.add_argument("--yes", "-y", action="store_true",

--- a/snet_cli/commands.py
+++ b/snet_cli/commands.py
@@ -15,10 +15,9 @@ from snet_cli.utils import DefaultAttributeObject, get_web3, serializable, type_
 from snet_cli.utils_config import get_contract_address, get_field_from_args_or_session
 from snet_cli.identity import RpcIdentityProvider, MnemonicIdentityProvider, TrezorIdentityProvider, \
     LedgerIdentityProvider, KeyIdentityProvider, KeyStoreIdentityProvider
-import web3
+from web3.eth import is_checksum_address
 import secrets
 import string
-from web3 import middleware
 from web3.gas_strategies.time_based import fast_gas_price_strategy, medium_gas_price_strategy, slow_gas_price_strategy
 
 
@@ -348,7 +347,7 @@ class OrganizationCommand(BlockchainCommand):
             return []
         members = [m.replace("[", "").replace("]", "") for m in self.args.members.split(',')]
         for m in members:
-            if not web3.eth.is_checksum_address(m):
+            if not is_checksum_address(m):
                 raise Exception("Member account %s is not a valid Ethereum checksum address"%m)
         return members
 
@@ -461,7 +460,7 @@ class OrganizationCommand(BlockchainCommand):
         self.error_organization_not_found(org_id, found)
 
         new_owner = self.args.owner
-        if not web3.eth.is_checksum_address(new_owner):
+        if not is_checksum_address(new_owner):
             raise Exception("New owner account %s is not a valid Ethereum checksum address"%new_owner)
 
         if new_owner.lower() == owner.lower():

--- a/snet_cli/commands.py
+++ b/snet_cli/commands.py
@@ -85,24 +85,24 @@ class VersionCommand(Command):
         self._pprint({"version": get_cli_version()})
 
 
-class cached_gas_price_strategy:
+class cachedGasPriceStrategy:
     def __init__(self, gas_price_param):
         self.gas_price_param = gas_price_param
         self.cached_gas_price = None
-    def __call__(self, web3, transaction_params):
+    def __call__(self, w3, transaction_params):
         if (self.cached_gas_price is None):
-            self.cached_gas_price = self.calc_gas_price(web3, transaction_params)
+            self.cached_gas_price = self.calc_gas_price(w3, transaction_params)
         return self.cached_gas_price
-    def calc_gas_price(self, web3, transaction_params):
+    def calc_gas_price(self, w3, transaction_params):
         gas_price_param = self.gas_price_param
         if (gas_price_param.isdigit()):
             return int(self.gas_price_param)
         if (gas_price_param == "fast"):
-            return (fast_gas_price_strategy(web3, transaction_params))
+            return (fast_gas_price_strategy(w3, transaction_params))
         if (gas_price_param == "medium"):
-            return (medium_gas_price_strategy(web3, transaction_params))
+            return (medium_gas_price_strategy(w3, transaction_params))
         if (gas_price_param == "slow"):
-            return (slow_gas_price_strategy(web3, transaction_params))
+            return (slow_gas_price_strategy(w3, transaction_params))
         raise Exception("Unknown gas price strategy: %s"%gas_price_param)
     def is_going_to_calculate(self):
         return self.cached_gas_price is None and not self.gas_price_param.isdigit()
@@ -113,8 +113,8 @@ class BlockchainCommand(Command):
         super(BlockchainCommand, self).__init__(config, args, out_f, err_f)
         self.w3 = w3 or get_web3(self.get_eth_endpoint())
         self.ident = ident or self.get_identity()
-        if (type(self.w3.eth.gasPriceStrategy) != cached_gas_price_strategy):
-            self.w3.eth.setGasPriceStrategy(cached_gas_price_strategy(self.get_gas_price_param()))
+        if (type(self.w3.eth.gasPriceStrategy) != cachedGasPriceStrategy):
+            self.w3.eth.setGasPriceStrategy(cachedGasPriceStrategy(self.get_gas_price_param()))
 
     def get_eth_endpoint(self):
         # the only one source of eth_rpc_endpoint is the configuration file

--- a/snet_cli/commands.py
+++ b/snet_cli/commands.py
@@ -117,10 +117,11 @@ class BlockchainCommand(Command):
             self.w3.eth.setGasPriceStrategy(slow_gas_price_strategy)
         else:
             raise Exception("Unknown gas price strategy: %s"%gas_price_param)
-        if (middleware.time_based_cache_middleware not in self.w3.middleware_stack):
-            self.w3.middleware_stack.add(middleware.time_based_cache_middleware)
-            self.w3.middleware_stack.add(middleware.latest_block_based_cache_middleware)
-            self.w3.middleware_stack.add(middleware.simple_cache_middleware)
+# TODO: Uncomment then bug with middleware (wrong result of getTransactionCount in Contract. build_transaction) will be fixed
+#        if (middleware.time_based_cache_middleware not in self.w3.middleware_stack):
+#            self.w3.middleware_stack.add(middleware.time_based_cache_middleware)
+#            self.w3.middleware_stack.add(middleware.latest_block_based_cache_middleware)
+#            self.w3.middleware_stack.add(middleware.simple_cache_middleware)
 
     def get_gas_price_verbose(self):
         if (self.is_gas_price_strategy):

--- a/snet_cli/config.py
+++ b/snet_cli/config.py
@@ -176,10 +176,10 @@ class Config(ConfigParser):
         """ Create default configuration if config file does not exist """
         # make config directory with the minimal possible permission
         self._config_file.parent.mkdir(mode=0o700, exist_ok=True)
-        self["network.kovan"]   = {"default_eth_rpc_endpoint": "https://kovan.infura.io",   "default_gas_price" : "1000000000"}
-        self["network.mainnet"] = {"default_eth_rpc_endpoint": "https://mainnet.infura.io", "default_gas_price" : "1000000000"}
-        self["network.ropsten"] = {"default_eth_rpc_endpoint": "https://ropsten.infura.io", "default_gas_price" : "1000000000"}
-        self["network.rinkeby"] = {"default_eth_rpc_endpoint": "https://rinkeby.infura.io", "default_gas_price" : "1000000000"}
+        self["network.kovan"]   = {"default_eth_rpc_endpoint": "https://kovan.infura.io",   "default_gas_price" : "medium"}
+        self["network.mainnet"] = {"default_eth_rpc_endpoint": "https://mainnet.infura.io", "default_gas_price" : "medium"}
+        self["network.ropsten"] = {"default_eth_rpc_endpoint": "https://ropsten.infura.io", "default_gas_price" : "medium"}
+        self["network.rinkeby"] = {"default_eth_rpc_endpoint": "https://rinkeby.infura.io", "default_gas_price" : "medium"}
         self["ipfs"] = {"default_ipfs_endpoint": "http://ipfs.singularitynet.io:80"}
         self["session"] = {
         "network": "kovan" }

--- a/test/functional_tests/script1_twogroups.sh
+++ b/test/functional_tests/script1_twogroups.sh
@@ -38,10 +38,10 @@ ipfs cat $IPFS_HASH > service_metadata2.json
 # compare service_metadata.json and service_metadata2.json
 cmp <(jq -S . service_metadata.json) <(jq -S . service_metadata2.json)
 
-snet organization create org1 --org-id testo -y -q
-snet service publish testo tests -y -q
-snet service update-add-tags testo tests tag1 tag2 tag3 -y -q
-snet service update-remove-tags testo tests tag2 tag1 -y -q
+snet organization create org1 --org-id testo -y -q  --gas-price fast
+snet service publish testo tests -y -q  --gas-price medium
+snet service update-add-tags testo tests tag1 tag2 tag3 -y -q --gas-price slow
+snet service update-remove-tags testo tests tag2 tag1 -y -q  --gas-price 1000000000
 snet service print-tags  testo tests
 
 # it should have only tag3 now


### PR DESCRIPTION
fix #223 

This PR add possibility to use time based gas price strategies (https://web3py.readthedocs.io/en/stable/gas_price.html).
We can set gas price as following:
- gas price in Wei (integer)
- 'fast' - Transaction mined within ~60 seconds.
- 'medium' - Transaction mined within ~5 minutes.
- 'slow'  - Transaction mined within 1 hour.

I've set ```--gas-price=medium``` by default for all networks including mainnet. 
@raamb Maybe we should default it to ```fast``` for mainnet to improve user experience?