### PR TITLE
Metadata remove endpoints

### DIFF
--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -695,7 +695,6 @@ def add_mpe_service_options(parser):
     add_p_publish_params(p)
     add_p_service_in_registry(p)
     add_transaction_arguments(p)
-    p.add_argument("--force", action="store_true", help="Force update metadata")
 
     p = subparsers.add_parser("update-add-tags", help="Add tags to existed service registration")
     p.set_defaults(fn="update_registration_add_tags")

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -667,6 +667,13 @@ def add_mpe_service_options(parser):
     add_p_metadata_file_opt(p)
 
 
+    p = subparsers.add_parser("metadata-update-endpoints", help="Remove all endpoints from the group and add new ones")
+    p.set_defaults(fn="metadata_update_endpoints")
+    p.add_argument("endpoints", nargs="+",  help="endpoints")
+    p.add_argument("--group-name", default=None, help="name of the payment group to which we want to add endpoints. Parameter should be specified in case of several payment groups")
+    add_p_metadata_file_opt(p)
+
+
     p = subparsers.add_parser("metadata-add-description", help="Add service description")
     p.set_defaults(fn="metadata_add_description")
     p.add_argument("--json",        default=None,  help="Service description in json")

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -662,6 +662,11 @@ def add_mpe_service_options(parser):
     p.add_argument("--group-name", default=None, help="name of the payment group to which we want to add endpoints. Parameter should be specified in case of several payment groups")
     add_p_metadata_file_opt(p)
 
+    p = subparsers.add_parser("metadata-remove-all-endpoints", help="Remove all endpoints from metadata")
+    p.set_defaults(fn="metadata_remove_all_endpoints")
+    add_p_metadata_file_opt(p)
+
+
     p = subparsers.add_parser("metadata-add-description", help="Add service description")
     p.set_defaults(fn="metadata_add_description")
     p.add_argument("--json",        default=None,  help="Service description in json")

--- a/snet_cli/mpe_service_command.py
+++ b/snet_cli/mpe_service_command.py
@@ -60,6 +60,12 @@ class MPEServiceCommand(BlockchainCommand):
             metadata.add_endpoint(group_name, endpoint)
         metadata.save_pretty(self.args.metadata_file)
 
+    def metadata_remove_all_endpoints(self):
+        """ Metadata: remove all endpoints from all groups """
+        metadata = load_mpe_service_metadata(self.args.metadata_file)
+        metadata.remove_all_endpoints()
+        metadata.save_pretty(self.args.metadata_file)
+
     def metadata_add_description(self):
         """ Metadata: add description """
         service_description = {}
@@ -109,18 +115,17 @@ class MPEServiceCommand(BlockchainCommand):
 
     def publish_metadata_in_ipfs_and_update_registration(self):
         # first we check that we do not change payment_address or group_id in existed payment groups
-        if (not self.args.force):
-            old_metadata = self._get_service_metadata_from_registry()
-            new_metadata = load_mpe_service_metadata(self.args.metadata_file)
-            for old_group in old_metadata["groups"]:
-                if (new_metadata.is_group_name_exists(old_group["group_name"])):
-
-                    new_group = new_metadata.get_group(old_group["group_name"])
-                    if (new_group["group_id"] != old_group["group_id"] or new_group["payment_address"] != old_group["payment_address"]):
-                        raise Exception("You are trying to change group_id or payment_address in group '%s'.\n"%old_group["group_name"] +
-                                         "You will make all open channels invalid.\n" +
-                                         "Use --force if you really want it.")
-
+        old_metadata = self._get_service_metadata_from_registry()
+        new_metadata = load_mpe_service_metadata(self.args.metadata_file)
+        for old_group in old_metadata["groups"]:
+            if (new_metadata.is_group_name_exists(old_group["group_name"])):
+                new_group = new_metadata.get_group(old_group["group_name"])
+                if (new_group["group_id"] != old_group["group_id"] or new_group["payment_address"] != old_group["payment_address"]):
+                    raise Exception("\n\nYou are trying to change group_id or payment_address in group '%s'.\n"%old_group["group_name"] +
+                                    "It would make all open channels invalid.\n" +
+                                    "You shoudn't use 'metadata-init' for existed service, because it reinitialize group_id\n" +
+                                    "Please use 'metadata-set-model' for change your protobuf file\n" +
+                                    "Please use 'metadata-remove-all-endpoints/metadata-add-endpoints to update endpoints'\n\n")
         metadata_uri     = hash_to_bytesuri( self._publish_metadata_in_ipfs(self.args.metadata_file))
         params           = [type_converter("bytes32")(self.args.org_id), type_converter("bytes32")(self.args.service_id), metadata_uri]
         self.transact_contract_command("Registry", "updateServiceRegistration", params)

--- a/snet_cli/mpe_service_command.py
+++ b/snet_cli/mpe_service_command.py
@@ -66,6 +66,15 @@ class MPEServiceCommand(BlockchainCommand):
         metadata.remove_all_endpoints()
         metadata.save_pretty(self.args.metadata_file)
 
+    def metadata_update_endpoints(self):
+        """ Metadata: Remove all endpoints from the group and add new ones """
+        metadata = load_mpe_service_metadata(self.args.metadata_file)
+        group_name = metadata.get_group_name_nonetrick(self.args.group_name)
+        metadata.remove_all_endpoints_for_group(group_name)
+        for endpoint in self.args.endpoints:
+            metadata.add_endpoint(group_name, endpoint)
+        metadata.save_pretty(self.args.metadata_file)
+
     def metadata_add_description(self):
         """ Metadata: add description """
         service_description = {}

--- a/snet_cli/mpe_service_metadata.py
+++ b/snet_cli/mpe_service_metadata.py
@@ -93,6 +93,9 @@ class MPEServiceMetadata:
             raise Exception("the endpoint %s is already present"%str(endpoint))
         self.m["endpoints"] += [{"group_name" : group_name, "endpoint"   : endpoint}]
 
+    def remove_all_endpoints(self):
+        self.m["endpoints"] = []
+
     def is_group_name_exists(self, group_name):
         """ check if group with given name is already exists """
         groups = self.m["groups"]

--- a/snet_cli/mpe_service_metadata.py
+++ b/snet_cli/mpe_service_metadata.py
@@ -96,6 +96,9 @@ class MPEServiceMetadata:
     def remove_all_endpoints(self):
         self.m["endpoints"] = []
 
+    def remove_all_endpoints_for_group(self, group_name):
+        self.m["endpoints"] = [e for e in self.m["endpoints"] if e["group_name"] != group_name]
+
     def is_group_name_exists(self, group_name):
         """ check if group with given name is already exists """
         groups = self.m["groups"]

--- a/test/functional_tests/script11_update_metadata.sh
+++ b/test/functional_tests/script11_update_metadata.sh
@@ -9,12 +9,10 @@ snet service publish testo tests -y -q
 snet service metadata-init ./service_spec1/ ExampleService 0x52653A9091b5d5021bed06c5118D24b23620c529  --fixed-price 0.0001 --endpoints 8.8.8.8:2020 --metadata-file service_metadata2.json
 
 snet service update-metadata testo tests --metadata-file service_metadata2.json -yq && exit 1 || echo "fail as expected"
-snet service update-metadata testo tests --metadata-file service_metadata2.json -yq --force
 
 #change payment_address
-cat service_metadata2.json | jq '.groups[0].payment_address = "0xc7973537517BfDeA79EE11Fa2D52584241a34dF2"' > service_metadata3.json
-snet service update-metadata testo tests --metadata-file service_metadata3.json -yq && exit 1 || echo "fail as expected"
-snet service update-metadata testo tests --metadata-file service_metadata3.json -yq --force
+cat service_metadata.json | jq '.groups[0].payment_address = "0xc7973537517BfDeA79EE11Fa2D52584241a34dF2"' > service_metadata2.json
+snet service update-metadata testo tests --metadata-file service_metadata2.json -yq && exit 1 || echo "fail as expected"
 
 
 # case with several groups
@@ -33,16 +31,11 @@ cat service_metadata.json | jq '.groups[1].group_id = "B5r64fQiiB5kvkWZDo7lXmo4i
 mv -f service_metadata2.json service_metadata.json
 
 snet service update-metadata testo tests -yq && exit 1 || echo "fail as expected"
-snet service update-metadata testo tests -yq --force
 
 
 #change payment_address
+snet service print-metadata testo tests > service_metadata.json
 cat service_metadata.json | jq '.groups[1].payment_address = "0xc7973537517BfDeA79EE11Fa2D52584241a34dF2"' > service_metadata2.json
 mv -f service_metadata2.json service_metadata.json
 
 snet service update-metadata testo tests -yq && exit 1 || echo "fail as expected"
-snet service update-metadata testo tests -yq --force
-
-snet service print-metadata  testo tests > service_metadata3.json
-
-cmp <(jq -S . service_metadata.json) <(jq -S . service_metadata3.json)

--- a/test/functional_tests/script1_twogroups.sh
+++ b/test/functional_tests/script1_twogroups.sh
@@ -28,6 +28,15 @@ snet service  metadata-remove-all-endpoints
 grep "8.8.8.8:2020" service_metadata.json && exit 1 || echo "fail as expected"
 snet service metadata-add-endpoints  8.8.8.8:2020 9.8.9.8:8080 --group-name group1
 snet service metadata-add-endpoints  8.8.8.8:22   1.2.3.4:8080 --group-name group2
+snet service metadata-update-endpoints 8.8.8.8:23456  1.2.3.4:22 --group-name group2
+grep "8.8.8.8:23456" service_metadata.json
+grep "8.8.8.8:2020" service_metadata.json
+grep "9.8.9.8:8080" service_metadata.json
+grep "8.8.8.8:22" service_metadata.json && exit 1 || echo "fail as expected"
+grep "1.2.3.4:8080" service_metadata.json && exit 1 || echo "fail as expected"
+
+
+
 
 snet service metadata-set-fixed-price 0.0001
 
@@ -99,6 +108,12 @@ snet channel print-all-filter-sender |grep 0x42A605c07EdE0E1f648aB054775D6D4E384
 # we have two initilized channels one for group1 and anther for group1 (recipient=0x42A605c07EdE0E1f648aB054775D6D4E38496144)
 
 snet service metadata-init ./service_spec1/ ExampleService 0x52653A9091b5d5021bed06c5118D24b23620c529  --fixed-price 0.0001 --endpoints 8.8.8.8:2020 --metadata-file service_metadata2.json
+grep "8.8.8.8:2020" service_metadata2.json
+snet service metadata-update-endpoints 8.8.8.8:2025 --metadata-file service_metadata2.json
+grep "8.8.8.8:2025" service_metadata2.json
+grep "8.8.8.8:2020" service_metadata2.json && exit 1 || echo "fail as expected"
+
+
 snet service publish testo tests2 -y -q --metadata-file service_metadata2.json
 
 snet channel open-init testo tests2 7234.345 1 -y  -q --signer 0x3b2b3C2e2E7C93db335E69D827F3CC4bC2A2A2cB

--- a/test/functional_tests/script1_twogroups.sh
+++ b/test/functional_tests/script1_twogroups.sh
@@ -23,6 +23,12 @@ snet service metadata-add-description --json '{"url":"http://127.0.0.1"}' --url 
 snet service metadata-add-group group2 0x0067b427E299Eb2A4CBafc0B04C723F77c6d8a18
 snet service metadata-add-endpoints  8.8.8.8:2020 9.8.9.8:8080 --group-name group1
 snet service metadata-add-endpoints  8.8.8.8:22   1.2.3.4:8080 --group-name group2
+grep "8.8.8.8:2020" service_metadata.json
+snet service  metadata-remove-all-endpoints
+grep "8.8.8.8:2020" service_metadata.json && exit 1 || echo "fail as expected"
+snet service metadata-add-endpoints  8.8.8.8:2020 9.8.9.8:8080 --group-name group1
+snet service metadata-add-endpoints  8.8.8.8:22   1.2.3.4:8080 --group-name group2
+
 snet service metadata-set-fixed-price 0.0001
 
 # test --endpoints and --fixed-price options in 'snet service metadata-init'


### PR DESCRIPTION
This PR does following

- Add 'snet service metadata-remove-all-endpoints' command which remove all endpoints from metadata file
- remove '--force' option from 'snet service update-metadata' which fully remove possibility to accidentally change ```group_id``` or ```payment_address``` for existed services (in case of emergency it is always possible to remove service and add it again).

In case user try to update ```group_id``` or ```payment_address``` for existed service (by running ```snet service metadata-update```)  he will see the following error message:
```
You are trying to change group_id or payment_address in group '.....'.
It would make all open channels invalid.
You shoudn't use 'metadata-init' for existed service, because it reinitialize group_id
Please use 'metadata-set-model' for change your protobuf file
Please use 'metadata-remove-all-endpoints/metadata-add-endpoints to update endpoints
```