### PR TITLE
convert gas price to int

### DIFF
--- a/snet_cli/commands.py
+++ b/snet_cli/commands.py
@@ -91,7 +91,7 @@ class cachedGasPriceStrategy:
         self.cached_gas_price = None
     def __call__(self, w3, transaction_params):
         if (self.cached_gas_price is None):
-            self.cached_gas_price = self.calc_gas_price(w3, transaction_params)
+            self.cached_gas_price = int(self.calc_gas_price(w3, transaction_params))
         return self.cached_gas_price
     def calc_gas_price(self, w3, transaction_params):
         gas_price_param = self.gas_price_param


### PR DESCRIPTION
This PR fix a small bug (which was reported to me, but which I was fail to reproduce in my enviroment). Apparently ```web3.*_gas_price_strategy``` sometimes return gas price in float (which cause an exception downstream because web3 itself do not accept gas price in float), so it should be converted to ```int``` manually.  