### PR TITLE
Support saving nested fields from service response

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,8 @@ jobs:
     - run:
         name: Unit tests
         command: |
-            bash -ex test/utils/run_all_unit.sh
+            sudo pip3 install nose
+            nosetests -v --with-doctest
     - run:
         name: Functional tests
         command: |

--- a/snet_cli/mpe_client_command.py
+++ b/snet_cli/mpe_client_command.py
@@ -1,5 +1,4 @@
 from snet_cli.mpe_channel_command import MPEChannelCommand
-from snet_cli.utils import compile_proto
 import base64
 from pathlib import Path
 import json
@@ -8,7 +7,7 @@ import grpc
 from eth_account.messages import defunct_hash_message
 from snet_cli.utils_proto import import_protobuf_from_dir, switch_to_json_payload_encoding
 from snet_cli.utils_agi2cogs import cogs2stragi
-from snet_cli.utils import open_grpc_channel
+from snet_cli.utils import open_grpc_channel, rgetattr, compile_proto
 
 
 # we inherit MPEChannelCommand because client needs channels
@@ -113,24 +112,13 @@ class MPEClientCommand(MPEChannelCommand):
                     ("snet-payment-channel-signature-bin", bytes(signature))]
         return call_fn(request, metadata=metadata)
 
-    def _get_field(self, field, response):
-        field_parts = field.split(".", 1)
-        field_name = field_parts[0]
-        try:
-            field_value = getattr(response, field_name)
-            if len(field_parts) == 2:
-                return self._get_field(field_parts[1], field_value)
-            else:
-                return field_value
-        except AttributeError:
-            raise Exception("Field {} not found in message" % field_name)
-
     def _deal_with_call_response(self, response):
         if (self.args.save_response):
             with open(self.args.save_response, "wb") as f:
                 f.write(response.SerializeToString())
         elif (self.args.save_field):
-            field = self._get_field(self.args.save_field[0], response)
+            field = rgetattr(response, self.args.save_field[0])
+            #field = self._get_field(, response)
             file_name = self.args.save_field[1]
             if (type(field) == bytes):
                 with open(file_name, "wb") as f:

--- a/snet_cli/mpe_client_command.py
+++ b/snet_cli/mpe_client_command.py
@@ -118,7 +118,6 @@ class MPEClientCommand(MPEChannelCommand):
                 f.write(response.SerializeToString())
         elif (self.args.save_field):
             field = rgetattr(response, self.args.save_field[0])
-            #field = self._get_field(, response)
             file_name = self.args.save_field[1]
             if (type(field) == bytes):
                 with open(file_name, "wb") as f:

--- a/snet_cli/utils.py
+++ b/snet_cli/utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+import functools
 
 from urllib.parse import urlparse
 from pathlib import Path
@@ -224,3 +225,14 @@ def open_grpc_channel(endpoint):
     if (endpoint.startswith("https://")):
         return grpc.secure_channel(remove_http_https_prefix(endpoint), grpc.ssl_channel_credentials())
     return grpc.insecure_channel(remove_http_https_prefix(endpoint))
+
+def rgetattr(obj, attr):
+    """
+    >>> from types import SimpleNamespace
+    >>> args = SimpleNamespace(a=1, b=SimpleNamespace(c=2, d='e'))
+    >>> rgetattr(args, "a")
+    1
+    >>> rgetattr(args, "b.c")
+    2
+    """
+    return functools.reduce(getattr, [obj] + attr.split('.'))

--- a/test/utils/run_all_unit.sh
+++ b/test/utils/run_all_unit.sh
@@ -1,1 +1,0 @@
-nosetests -v --with-doctest

--- a/test/utils/run_all_unit.sh
+++ b/test/utils/run_all_unit.sh
@@ -1,4 +1,1 @@
-for f in test/unit_tests/*.py
-do
-   bash -ex -c "cd test/unit_tests; python `basename $f`"
-done
+nosetests -v --with-doctest


### PR DESCRIPTION
`--save-field` currently assumes that protobuf messages are flat, this PR allows the user to use a dot notation to access nested fields.

Example use:

```
snet channel open-init snet semantic-segmentation  0.001 +10days
snet client call --save-field debug_img.content output.jpg snet semantic-segmentation segment '{"img": {"file@content":"test.jpg", "mimetype": "image/jpeg"}, "visualise":true}'
```