### PR TITLE
Implement compilation of node.js client libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 snet_cli/resources/contracts/abi
 snet_cli/resources/contracts/networks
 snet_cli/resources/proto/*.py
+snet_cli/resources/node_modules
 build/
 dist/
 client_libraries/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include snet_cli/resources/proto/*
 include snet_cli/resources/contracts/abi/*
 include snet_cli/resources/contracts/networks/*
+include snet_cli/resources/package.json
 include snet_cli/_vendor/*

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -1092,6 +1092,7 @@ def add_sdk_options(parser):
     add_p_service_in_registry(p)
     p.add_argument("protodir",
                    nargs="?",
+                   default="client_libraries",
                    help="Directory where to output the generated client libraries",
                    metavar="PROTO_DIR")
     add_eth_call_arguments(p)

--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -1080,7 +1080,7 @@ def add_sdk_options(parser):
     subparsers = parser.add_subparsers(title="Commands", metavar="COMMAND")
     subparsers.required = True
 
-    supported_languages = ["python"]
+    supported_languages = ["python", "nodejs"]
 
     p = subparsers.add_parser("generate-client-library",
                               help="Generate compiled client libraries to call services using your language of choice")

--- a/snet_cli/resources/package.json
+++ b/snet_cli/resources/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "grpc-tools": "1.7.3"
+  }
+}

--- a/snet_cli/sdk_command.py
+++ b/snet_cli/sdk_command.py
@@ -9,20 +9,14 @@ from snet_cli.mpe_service_metadata import mpe_service_metadata_from_json
 
 class SDKCommand(MPEServiceCommand):
     def generate_client_library(self):
-        cur_dir_path = PurePath(os.getcwd())
 
-        if not self.args.protodir:
-            client_libraries_base_dir_path = cur_dir_path.joinpath("client_libraries")
-            if not os.path.exists(client_libraries_base_dir_path):
-                os.makedirs(client_libraries_base_dir_path)
+        if os.path.isabs(self.args.protodir):
+            client_libraries_base_dir_path = PurePath(self.args.protodir)
         else:
-            if os.path.isabs(self.args.protodir):
-                client_libraries_base_dir_path = PurePath(self.args.protodir)
-            else: 
-                client_libraries_base_dir_path = cur_dir_path.joinpath(self.args.protodir)
+            cur_dir_path = PurePath(os.getcwd())
+            client_libraries_base_dir_path = cur_dir_path.joinpath(self.args.protodir)
 
-            if not os.path.isdir(client_libraries_base_dir_path):
-                self._error("directory {} does not exist. Please make sure that the specified path exists".format(client_libraries_base_dir_path))
+        os.makedirs(client_libraries_base_dir_path, exist_ok = True)
 
         # Create service client libraries path
         library_language = self.args.language

--- a/snet_cli/sdk_command.py
+++ b/snet_cli/sdk_command.py
@@ -5,7 +5,6 @@ from tempfile import TemporaryDirectory
 
 from snet_cli.utils import type_converter, bytes32_to_str, compile_proto
 from snet_cli.utils_ipfs import bytesuri_to_hash, get_from_ipfs_and_checkhash, safe_extract_proto_from_ipfs
-from snet_cli.utils_config import get_contract_address
 from snet_cli.mpe_service_metadata import mpe_service_metadata_from_json
 
 class SDKCommand(MPEServiceCommand):
@@ -30,17 +29,17 @@ class SDKCommand(MPEServiceCommand):
         library_org_id = self.args.org_id
         library_service_id = self.args.service_id
 
-        library_dir_path = client_libraries_base_dir_path.joinpath(library_language, get_contract_address(self, "Registry"), library_org_id, library_service_id)
+        library_dir_path = client_libraries_base_dir_path.joinpath(library_org_id, library_service_id, library_language)
 
         metadata = self._get_service_metadata_from_registry()
         model_ipfs_hash = metadata["model_ipfs_hash"]
 
         with TemporaryDirectory() as temp_dir: 
             temp_dir_path = PurePath(temp_dir)
-            proto_temp_dir_path = temp_dir_path.joinpath(library_language, library_org_id, library_service_id)
+            proto_temp_dir_path = temp_dir_path.joinpath(library_org_id, library_service_id, library_language)
             safe_extract_proto_from_ipfs(self._get_ipfs_client(), model_ipfs_hash, proto_temp_dir_path)
 
         # Compile proto files
-            compile_proto(Path(proto_temp_dir_path), library_dir_path)
+            compile_proto(Path(proto_temp_dir_path), library_dir_path, target_language=self.args.language)
 
         self._printout('client libraries for service with id "{}" in org with id "{}" generated at {}'.format(library_service_id, library_org_id, library_dir_path))

--- a/test/functional_tests/script15_sdk_generate_client_library.sh
+++ b/test/functional_tests/script15_sdk_generate_client_library.sh
@@ -1,0 +1,19 @@
+
+# simple case of one group
+snet service metadata-init ./service_spec1/ ExampleService 0x52653A9091b5d5021bed06c5118D24b23620c529  --fixed-price 0.0001 --endpoints 8.8.8.8:2020
+snet organization create testo --org-id testo -y -q
+snet service publish testo tests -y -q
+
+snet sdk generate-client-library python testo tests
+test -f client_libraries/testo/tests/python/ExampleService_pb2_grpc.py
+
+snet sdk generate-client-library nodejs testo tests
+test -f client_libraries/testo/tests/nodejs/ExampleService_grpc_pb.js
+
+# test relative path (and using already installed compiler)
+snet sdk generate-client-library nodejs testo tests snet_output
+test -f snet_output/testo/tests/nodejs/ExampleService_grpc_pb.js
+
+# test absolute path
+snet sdk generate-client-library nodejs testo tests /tmp/snet_output
+test -f /tmp/snet_output/testo/tests/nodejs/ExampleService_grpc_pb.js


### PR DESCRIPTION
Get node.js protoc compiler from npm on user's system (must be compiled
for the user's architecture, requires node.js to be used)
Allow users to compile client libraries for node.js