### PR TITLE
Ethereum address sanity check when generating from public key derived from private or mnemonic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
         'web3==4.8.3',
         'mnemonic==0.18',
         'pycoin>=0.80',
-        'ecdsa==0.13',
         'trezor==0.9.1',
         'rlp==1.0.1',
         'pyyaml>=4.2b1',

--- a/snet_cli/identity.py
+++ b/snet_cli/identity.py
@@ -47,8 +47,8 @@ class KeyIdentityProvider(IdentityProvider):
                                                   curve=ecdsa.SECP256k1,
                                                   hashfunc=hashlib.sha256).get_verifying_key()
 
-        self.address = self.w3.toChecksumAddress(
-            "0x" + self.w3.sha3(hexstr=public_key.to_string().hex())[12:].hex())
+        self.address = self.w3.sha3(hexstr=public_key.to_string().hex())[12:].hex()
+        self.address = self.w3.toChecksumAddress(self.address) if self.address.startswith("0x") else self.w3.toChecksumAddress("0x" + self.address)
 
     def get_address(self):
         return self.address
@@ -126,9 +126,9 @@ class MnemonicIdentityProvider(IdentityProvider):
         public_key = ecdsa.SigningKey.from_string(string=self.private_key,
                                                   curve=ecdsa.SECP256k1,
                                                   hashfunc=hashlib.sha256).get_verifying_key()
-
-        self.address = self.w3.toChecksumAddress(
-            "0x" + self.w3.sha3(hexstr=public_key.to_string().hex())[12:].hex())
+        
+        self.address = self.w3.sha3(hexstr=public_key.to_string().hex())[12:].hex()
+        self.address = self.w3.toChecksumAddress(self.address) if self.address.startswith("0x") else self.w3.toChecksumAddress("0x" + self.address)
 
     def get_address(self):
         return self.address


### PR DESCRIPTION
Verifying whether the address generated from the public key is already prefixed with 0x, in which case it's not added twice