### PR TITLE
Added capability to add/remove different type of assets to metadata file

### DIFF
--- a/packages/snet_cli/snet/snet_cli/mpe_service_metadata.py
+++ b/packages/snet_cli/snet/snet_cli/mpe_service_metadata.py
@@ -81,7 +81,7 @@ class MPEServiceMetadata:
 
     def set_simple_field(self, f, v):
         if (f != "display_name" and f != "encoding" and f != "model_ipfs_hash" and f != "mpe_address" and
-            f != "service_type" and f != "payment_expiration_threshold" and f != "service_description" and f!="hero_image_ipfs_hash"):
+            f != "service_type" and f != "payment_expiration_threshold" and f != "service_description"):
                 raise Exception("unknown field in MPEServiceMetadata")
         self.m[f] = v
 

--- a/packages/snet_cli/snet/snet_cli/mpe_service_metadata.py
+++ b/packages/snet_cli/snet/snet_cli/mpe_service_metadata.py
@@ -51,6 +51,13 @@ from snet.snet_cli.utils import is_valid_endpoint
 class AssetType(Enum):
     HERO_IMAGE = "hero_image"
     IMAGES = "images"
+    DOCUMENTATION = "documentation"
+    TERMS_OF_USE = "terms_of_use"
+
+    @staticmethod
+    def is_asset_having_single_value(asset_type):
+        if asset_type == AssetType.HERO_IMAGE.value or asset_type == AssetType.DOCUMENTATION.value or asset_type == AssetType.TERMS_OF_USE.value:
+            return True
 
 
 # TODO: we should use some standard solution here
@@ -101,7 +108,7 @@ class MPEServiceMetadata:
             self.m['assets'] = {}
 
         # hero image will contain the single value
-        if asset_type == AssetType.HERO_IMAGE.value:
+        if AssetType.is_asset_having_single_value(asset_type):
             self.m['assets'][asset_type] = asset_ipfs_hash
 
         # images can contain multiple value
@@ -113,12 +120,13 @@ class MPEServiceMetadata:
         else:
             raise Exception("Invalid asset type %s"%asset_type)
 
+
     def remove_all_assets(self):
         self.m['assets'] = {}
 
     def remove_assets(self,asset_type):
         if 'assets' in self.m:
-            if asset_type == AssetType.HERO_IMAGE.value:
+            if AssetType.is_asset_having_single_value(asset_type):
                 self.m['assets'][asset_type] = ""
             elif asset_type == AssetType.IMAGES.value:
                 self.m['assets'][asset_type] = []

--- a/packages/snet_cli/snet/snet_cli/mpe_service_metadata.py
+++ b/packages/snet_cli/snet/snet_cli/mpe_service_metadata.py
@@ -23,17 +23,17 @@ pricing {}      -  Pricing model
              price_model   - "fixed_price"
              price_in_cogs -  unique fixed price in cogs for all method (1 AGI = 10^8 cogs)
              (other pricing models can be easily supported)
-[]       - group is the number of endpoints which shares same payment channel;
+groups []       - group is the number of endpoints which shares same payment channel;
                   grouping strategy is defined by service provider;
                   for example service provider can use region name as group name
      group_name - unique name of the group (human readable)
      group_id   - unique id of the group (random 32 byte string in base64 encoding)
      payment_address - Ethereum address to recieve payments
-endpoints[] - address in the off-chain network to provide a service
+endpoints[]     - address in the off-chain network to provide a service
      group_name
      endpoint   -  unique endpoint identifier (ip:port)
 
-assets {}       - contains asset type and its ipfs value/values
+assets {}       -  asset type and its ipfs value/values
 """
 
 import re

--- a/packages/snet_cli/snet/snet_cli/utils_ipfs.py
+++ b/packages/snet_cli/snet/snet_cli/utils_ipfs.py
@@ -7,6 +7,21 @@ import os
 import base58
 import multihash
 
+
+
+def publish_file_in_ipfs(ipfs_client, filepath):
+    """
+        push a file to ipfs given its path
+    """
+    try:
+        with open(filepath, 'w') as file:
+           result= ipfs_client.add(file)
+           return result['Hash']
+    except Exception as err:
+        print("File error ", err)
+
+
+
 def publish_proto_in_ipfs(ipfs_client, protodir):
     """
     make tar from protodir/*proto, and publish this tar in ipfs

--- a/packages/snet_cli/snet_cli/arguments.py
+++ b/packages/snet_cli/snet_cli/arguments.py
@@ -915,6 +915,29 @@ def add_mpe_service_options(parser):
     p.set_defaults(fn="metadata_remove_all_endpoints")
     add_p_metadata_file_opt(p)
 
+    p = subparsers.add_parser("metadata-add-assets",
+                              help="Add assets to metadata, valid asset types are [hero_image,images]")
+    p.set_defaults(fn="metadata_add_asset_to_ipfs")
+    p.add_argument("asset_file_path",
+                   help="Asset file path")
+    p.add_argument("asset_type",
+                   help="Type of the asset")
+    add_p_metadata_file_opt(p)
+
+    p = subparsers.add_parser("metadata-remove-assets",
+                              help="Remove asset of a given type valid asset types are [hero_image,images]")
+    p.set_defaults(fn="metadata_remove_assets_of_a_given_type")
+    p.add_argument("asset_type",
+                   help="Type of the asset to be removed , valid asset types are [hero_image,images]")
+    add_p_metadata_file_opt(p)
+
+
+    p = subparsers.add_parser("metadata-remove-all-assets",
+                              help="Remove all assets from metadata")
+    p.set_defaults(fn="metadata_remove_all_assets")
+    add_p_metadata_file_opt(p)
+
+
     p = subparsers.add_parser("metadata-update-endpoints",
                               help="Remove all endpoints from the group and add new ones")
     p.set_defaults(fn="metadata_update_endpoints")

--- a/packages/snet_cli/snet_cli/mpe_service_command.py
+++ b/packages/snet_cli/snet_cli/mpe_service_command.py
@@ -21,10 +21,11 @@ class MPEServiceCommand(BlockchainCommand):
         self._printout(ipfs_hash_base58)
 
     def publish_proto_metadata_init(self):
-        ipfs_hash_base58 = utils_ipfs.publish_proto_in_ipfs(self._get_ipfs_client(), self.args.protodir)
+        model_ipfs_hash_base58 = utils_ipfs.publish_proto_in_ipfs(self._get_ipfs_client(), self.args.protodir)
+
         metadata    = MPEServiceMetadata()
         mpe_address = self.get_mpe_address()
-        metadata.set_simple_field("model_ipfs_hash",              ipfs_hash_base58)
+        metadata.set_simple_field("model_ipfs_hash",              model_ipfs_hash_base58)
         metadata.set_simple_field("mpe_address",                  mpe_address)
         metadata.set_simple_field("display_name",                 self.args.display_name)
         metadata.set_simple_field("encoding",                     self.args.encoding)
@@ -81,6 +82,27 @@ class MPEServiceCommand(BlockchainCommand):
         for endpoint in self.args.endpoints:
             metadata.add_endpoint(group_name, endpoint)
         metadata.save_pretty(self.args.metadata_file)
+
+
+    def metadata_add_asset_to_ipfs(self):
+        metadata = load_mpe_service_metadata(self.args.metadata_file)
+        asset_file_ipfs_hash_base58 = utils_ipfs.publish_file_in_ipfs(self._get_ipfs_client(),
+                                                                       self.args.asset_file_path)
+
+        metadata.add_asset(asset_file_ipfs_hash_base58, self.args.asset_type)
+        metadata.save_pretty(self.args.metadata_file)
+
+    def metadata_remove_all_assets(self):
+        metadata = load_mpe_service_metadata(self.args.metadata_file)
+        metadata.remove_all_assets()
+        metadata.save_pretty(self.args.metadata_file)
+
+    def metadata_remove_assets_of_a_given_type(self):
+        metadata = load_mpe_service_metadata(self.args.metadata_file)
+        metadata.remove_assets(self.args.asset_type)
+        metadata.save_pretty(self.args.metadata_file)
+
+
 
     def metadata_add_description(self):
         """ Metadata: add description """

--- a/packages/snet_cli/test/functional_tests/script11_update_metadata.sh
+++ b/packages/snet_cli/test/functional_tests/script11_update_metadata.sh
@@ -43,29 +43,31 @@ snet service update-metadata testo tests -yq && exit 1 || echo "fail as expected
 
 
 #add assets with single value
-snet service metadata-init ./service_spec1/ ExampleService 0x52653A9091b5d5021bed06c5118D24b23620c529
-snet --print-traceback service metadata-add-assets  ./service_spec1/ExampleService.proto hero_image
-snet --print-traceback service metadata-add-assets  ./service_spec1/ExampleService.proto terms_of_use
-result=$(cat service_metadata.json | jq '.assets.hero_image')
+snet service metadata-init ./service_spec1/ ExampleService 0x52653A9091b5d5021bed06c5118D24b23620c529 --metadata-file=service_asset_metadata.json
+snet --print-traceback service metadata-add-assets  ./service_spec1/ExampleService.proto hero_image  --metadata-file=service_asset_metadata.json
+snet --print-traceback service metadata-add-assets  ./service_spec1/ExampleService.proto terms_of_use  --metadata-file=service_asset_metadata.json
+result=$(cat service_asset_metadata.json | jq '.assets.hero_image')
 test $result = '"QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH"'  &&  echo "add asset with single value  test case passed " ||   exit 1
 
 
 #add assets with multiple values
-snet --print-traceback service metadata-add-assets  ./service_spec1/ExampleService.proto images
-snet --print-traceback service metadata-add-assets  ./service_spec1/ExampleService.proto images
-result=$(cat service_metadata.json | jq '.assets.images[1]')
+snet --print-traceback service metadata-add-assets  ./service_spec1/ExampleService.proto images --metadata-file=service_asset_metadata.json
+snet --print-traceback service metadata-add-assets  ./service_spec1/ExampleService.proto images --metadata-file=service_asset_metadata.json
+result=$(cat service_asset_metadata.json | jq '.assets.images[1]')
 test $result = '"QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH"'  &&  echo "add asset with multiple value  test case passed " ||   exit 1
 
 
 
 #remove assets
-snet  service metadata-remove-assets hero_image
-result=$(cat service_metadata.json | jq '.assets.hero_image')
+snet  --print-traceback service metadata-remove-assets hero_image --metadata-file=service_asset_metadata.json
+result=$(cat service_asset_metadata.json | jq '.assets.hero_image')
 test $result = '""'  &&  echo "metadata-remove-assets  test case passed " ||   exit 1
 
 #remove all assets
-snet  service metadata-remove-all-assets
-result=$(cat service_metadata.json | jq '.assets')
+snet  --print-traceback service metadata-remove-all-assets --metadata-file=service_asset_metadata.json
+result=$(cat service_asset_metadata.json | jq '.assets')
 test $result = '{}'  &&  echo "metadata-remove-all-assets test case passed " ||   exit 1
+rm service_asset_metadata.json
+
 
 

--- a/packages/snet_cli/test/functional_tests/script11_update_metadata.sh
+++ b/packages/snet_cli/test/functional_tests/script11_update_metadata.sh
@@ -1,4 +1,5 @@
 
+
 # simple case of one group
 snet service metadata-init ./service_spec1/ ExampleService 0x52653A9091b5d5021bed06c5118D24b23620c529  --fixed-price 0.0001 --endpoints 8.8.8.8:2020
 snet organization create testo --org-id testo -y -q
@@ -39,3 +40,32 @@ cat service_metadata.json | jq '.groups[1].payment_address = "0xc7973537517BfDeA
 mv -f service_metadata2.json service_metadata.json
 
 snet service update-metadata testo tests -yq && exit 1 || echo "fail as expected"
+
+
+#add assets with single value
+snet service metadata-init ./service_spec1/ ExampleService 0x52653A9091b5d5021bed06c5118D24b23620c529
+snet --print-traceback service metadata-add-assets  ./service_spec1/ExampleService.proto hero_image
+snet --print-traceback service metadata-add-assets  ./service_spec1/ExampleService.proto terms_of_use
+result=$(cat service_metadata.json | jq '.assets.hero_image')
+test $result = '"QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH"'  &&  echo "add asset with single value  test case passed " ||   exit 1
+
+
+#add assets with multiple values
+snet --print-traceback service metadata-add-assets  ./service_spec1/ExampleService.proto images
+snet --print-traceback service metadata-add-assets  ./service_spec1/ExampleService.proto images
+result=$(cat service_metadata.json | jq '.assets.images[1]')
+test $result = '"QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH"'  &&  echo "add asset with multiple value  test case passed " ||   exit 1
+
+
+
+#remove assets
+snet  service metadata-remove-assets hero_image
+result=$(cat service_metadata.json | jq '.assets.hero_image')
+test $result = '""'  &&  echo "metadata-remove-assets  test case passed " ||   exit 1
+
+#remove all assets
+snet  service metadata-remove-all-assets
+result=$(cat service_metadata.json | jq '.assets')
+test $result = '{}'  &&  echo "metadata-remove-all-assets test case passed " ||   exit 1
+
+


### PR DESCRIPTION
New metadatafile will look something like this 
{
    "version": 1,
    "display_name": "test_sohit",
    "encoding": "proto",
    "service_type": "grpc",
    "payment_expiration_threshold": 40320,
    "model_ipfs_hash": "abc",
    "mpe_address": "abc",
    "pricing": {},
    "groups": [
        {
            "group_name": "default_group",
            "group_id": "xyz",
            "payment_address": "abc"
        }
    ],
    "endpoints": [],
    **"assets": {
        "images": [
            "abc",
            "def"
        ],
        "hero_image": "xyz"**
    },

under assets , different types of assets can be added, for example hero_image having single value, other images which can have multiple values.

We can discuss what all assets type we want to support and number of values associated with it.

commands added :
metadata-add-assets -  add assets of a given type
metadata-remove-assets- remove asset of a given type
metadata-remove-all-assets - remove all assets







