### PR TITLE
FIX: possible name clash in Python's gRPC symbols database.

### DIFF
--- a/packages/sdk/snet/sdk/__init__.py
+++ b/packages/sdk/snet/sdk/__init__.py
@@ -1,3 +1,13 @@
+import google.protobuf.internal.api_implementation
+
+google.protobuf.internal.api_implementation.Type = lambda: 'python'
+
+from google.protobuf import symbol_database as _symbol_database
+
+_sym_db = _symbol_database.Default()
+_sym_db.RegisterMessage = lambda x: None
+
+
 import json
 import base64
 from urllib.parse import urljoin


### PR DESCRIPTION
Each gRPC message in each compiled module in Python's gRPC
implementation has a reference saved in a symbols' database after it's
imported once. These messages are saved using their descriptor as the
key. The problem is that multiple messages from different services may
have the same message descriptor and an exception will be thrown if you
try to import multiple messages of such kind.

This fix essentially removes the use of this symbols' database for
messages by overriding the function that registers such messages.

The problem only presents itself if the user tries to import multiple
services with messages with clashing descriptors and the fix requires
the user to import the SDK before any gRPC message file. However, if the
user knows that none of the services they are using have clashing
message names, they may elect to import the SDK after those messages and
still use this symbols' database.