### PR TITLE
retain filename in assets

### DIFF
--- a/packages/snet_cli/snet/snet_cli/utils_ipfs.py
+++ b/packages/snet_cli/snet/snet_cli/utils_ipfs.py
@@ -13,9 +13,9 @@ def publish_file_in_ipfs(ipfs_client, filepath):
         push a file to ipfs given its path
     """
     try:
-        with open(filepath, 'w') as file:
-            result = ipfs_client.add(file)
-            return result['Hash']
+        with open(filepath, 'r+b') as file:
+            result = ipfs_client.add(file,pin=True,wrap_with_directory=True)
+            return  result[1]['Hash']+'/'+result[0]['Name']
     except Exception as err:
         print("File error ", err)
 

--- a/packages/snet_cli/test/functional_tests/script11_update_metadata.sh
+++ b/packages/snet_cli/test/functional_tests/script11_update_metadata.sh
@@ -44,13 +44,13 @@ snet service metadata-init ./service_spec1/ ExampleService 0x52653A9091b5d5021be
 snet --print-traceback service metadata-add-assets ./service_spec1/test hero_image --metadata-file=service_asset_metadata.json
 snet --print-traceback service metadata-add-assets ./service_spec1/test terms_of_use --metadata-file=service_asset_metadata.json
 result=$(cat service_asset_metadata.json | jq '.assets.hero_image')
-test $result = '"QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH"' && echo "add asset with single value  test case passed " || exit 1
+test $result = '"QmSW7UtAuqEekS44H3yTqDSJM2WV6GiTXG8crhSideUSF3/test"' && echo "add asset with single value  test case passed " || exit 1
 
 #add assets with multiple values
 snet --print-traceback service metadata-add-assets ./service_spec1/test images --metadata-file=service_asset_metadata.json
 snet --print-traceback service metadata-add-assets ./service_spec1/test images --metadata-file=service_asset_metadata.json
 result=$(cat service_asset_metadata.json | jq '.assets.images[1]')
-test $result = '"QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH"' && echo "add asset with multiple value  test case passed " || exit 1
+test $result = '"QmSW7UtAuqEekS44H3yTqDSJM2WV6GiTXG8crhSideUSF3/test"' && echo "add asset with multiple value  test case passed " || exit 1
 
 #remove assets
 snet --print-traceback service metadata-remove-assets hero_image --metadata-file=service_asset_metadata.json


### PR DESCRIPTION
Idea is to retain filename when we push assets to ipfs.This will help us to retain the file formats and any read write eg: push/pull to s3 is  easy to handle.