### PR TITLE
FIX: waiting for killall command to actually stop the ipfs process before trying to delete its directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
             # Install platform-contracts (from master)
             # we will deploy contracts from packages/snet_cli/test/utils/reset_enviroment.sh
             cd ..
-            git clone https://github.com/singnet/platform-contracts
+            git clone --branch v0.3.0 https://github.com/singnet/platform-contracts
             cd platform-contracts
             npm install
             npm install ganache-cli

--- a/packages/snet_cli/test/utils/reset_environment.sh
+++ b/packages/snet_cli/test/utils/reset_environment.sh
@@ -14,9 +14,9 @@ fi
       
 
 # I. restart ipfs
-killall ipfs || echo "supress an error"
+killall -w ipfs || echo "supress an error"
 
-sudo rm -rf ~/.ipfs
+rm -rf ~/.ipfs
 ipfs init
 ipfs bootstrap rm --all
 ipfs config Addresses.API /ip4/127.0.0.1/tcp/5002
@@ -25,7 +25,7 @@ nohup ipfs daemon > ipfs.log 2>&1 &
 
 
 # II. restart ganache and remigrate platform-contracts
-killall node || echo "supress an error"
+killall -w node || echo "supress an error"
 
 cd ../platform-contracts
 nohup ./node_modules/.bin/ganache-cli --mnemonic 'gauge enact biology destroy normal tunnel slight slide wide sauce ladder produce' --networkId 829257324 > /dev/null &

--- a/packages/snet_cli/test/utils/reset_environment.sh
+++ b/packages/snet_cli/test/utils/reset_environment.sh
@@ -14,7 +14,7 @@ fi
       
 
 # I. restart ipfs
-killall -w ipfs || echo "supress an error"
+ipfs shutdown || echo "supress an error"
 
 rm -rf ~/.ipfs
 ipfs init
@@ -25,7 +25,7 @@ nohup ipfs daemon > ipfs.log 2>&1 &
 
 
 # II. restart ganache and remigrate platform-contracts
-killall -w node || echo "supress an error"
+killall node || echo "supress an error"
 
 cd ../platform-contracts
 nohup ./node_modules/.bin/ganache-cli --mnemonic 'gauge enact biology destroy normal tunnel slight slide wide sauce ladder produce' --networkId 829257324 > /dev/null &


### PR DESCRIPTION
If rm -rf is sent before the process is killed, hidden files in the ipfs directory will be in use by the FUSE mount and the deletion command will fail. Removing sudo as it's useless.