### PR TITLE
Setting Ropsten as default network.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,13 +54,11 @@ jobs:
         name: Set up for snet daemon
         command: |
           cd ..
-          mkdir snet-daemon
-          cd snet-daemon
-
-          wget https://github.com/singnet/snet-daemon/releases/download/v3.0.0/snet-daemon-v3.0.0-linux-amd64.tar.gz
-          tar -xvf snet-daemon-v3.0.0-linux-amd64.tar.gz
-          cd snet-daemon-v3.0.0-linux-amd64
-          cp ~/singnet/snet-cli/packages/sdk/testcases/functional_tests/snetd.config.json ~/singnet/snet-daemon/snet-daemon-v3.0.0-linux-amd64
+          SNETD_VERSION=`curl -s https://api.github.com/repos/singnet/snet-daemon/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")' || echo "v3.1.6"`
+          wget https://github.com/singnet/snet-daemon/releases/download/${SNETD_VERSION}/snet-daemon-${SNETD_VERSION}-linux-amd64.tar.gz
+          tar -xvf snet-daemon-${SNETD_VERSION}-linux-amd64.tar.gz
+          mv snet-daemon-${SNETD_VERSION}-linux-amd64 snet-daemon
+          cp ~/singnet/snet-cli/packages/sdk/testcases/functional_tests/snetd.config.json ~/singnet/snet-daemon/
 
 
     - run:

--- a/packages/sdk/testcases/utils/reset_environment.sh
+++ b/packages/sdk/testcases/utils/reset_environment.sh
@@ -43,7 +43,7 @@ snet network create local http://localhost:8545
 # swith to local network
 snet network local
 
-# Configure contract addresses for local network (it will not be necessary for kovan or mainnet! )
+# Configure contract addresses for local network (it will not be necessary for ropsten or mainnet! )
 snet set current_singularitynettoken_at 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14
 snet set current_registry_at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet set current_multipartyescrow_at 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e

--- a/packages/sdk/testcases/utils/reset_environment.sh
+++ b/packages/sdk/testcases/utils/reset_environment.sh
@@ -81,7 +81,7 @@ sh buildproto.sh
 nohup python3 run_example_service.py --no-daemon &
 
 
-cd ~/singnet/snet-daemon/snet-daemon-v3.0.0-linux-amd64
+cd ~/singnet/snet-daemon
 nohup ./snetd &
 
 #wait for daemon to come up

--- a/packages/snet_cli/snet_cli/config.py
+++ b/packages/snet_cli/snet_cli/config.py
@@ -181,8 +181,7 @@ class Config(ConfigParser):
         self["network.ropsten"] = {"default_eth_rpc_endpoint": "https://ropsten.infura.io/v3/09027f4a13e841d48dbfefc67e7685d5", "default_gas_price" : "medium"}
         self["network.rinkeby"] = {"default_eth_rpc_endpoint": "https://rinkeby.infura.io/v3/09027f4a13e841d48dbfefc67e7685d5", "default_gas_price" : "medium"}
         self["ipfs"] = {"default_ipfs_endpoint": "http://ipfs.singularitynet.io:80"}
-        self["session"] = {
-        "network": "kovan" }
+        self["session"] = {"network": "ropsten"}
         self._persist()
         print("We've created configuration file with default values in: %s\n"%str(self._config_file))
 

--- a/packages/snet_cli/test/functional_tests/script8_networks.sh
+++ b/packages/snet_cli/test/functional_tests/script8_networks.sh
@@ -11,6 +11,6 @@ snet network local_bad
 #switch to mainnet
 snet network mainnet
 
-#switch to kovan
-snet network kovan
+#switch to ropsten
+snet network ropsten
 

--- a/packages/snet_cli/test/utils/reset_environment.sh
+++ b/packages/snet_cli/test/utils/reset_environment.sh
@@ -43,7 +43,7 @@ snet network create local http://localhost:8545
 # swith to local network
 snet network local
 
-# Configure contract addresses for local network (it will not be necessary for kovan or mainnet! )
+# Configure contract addresses for local network (it will not be necessary for ropsten or mainnet! )
 snet set current_singularitynettoken_at 0x6e5f20669177f5bdf3703ec5ea9c4d4fe3aabd14
 snet set current_registry_at 0x4e74fefa82e83e0964f0d9f53c68e03f7298a8b2
 snet set current_multipartyescrow_at 0x5c7a4290f6f8ff64c69eeffdfafc8644a4ec3a4e


### PR DESCRIPTION
- Since we're mostly using just Rospen as testnet.
- CircleCI: Getting the latest Daemon release.