### PR TITLE
added snet-payment-mpe-address in paid call in snet-cli

### DIFF
--- a/packages/snet_cli/snet_cli/mpe_client_command.py
+++ b/packages/snet_cli/snet_cli/mpe_client_command.py
@@ -129,7 +129,8 @@ class MPEClientCommand(MPEChannelCommand):
                 ("snet-payment-channel-id",            str(channel_id)),
                 ("snet-payment-channel-nonce",         str(nonce)),
                 ("snet-payment-channel-amount",        str(amount)),
-                ("snet-payment-channel-signature-bin", bytes(signature))]
+                ("snet-payment-channel-signature-bin", bytes(signature)),
+                ("snet-payment-mpe-address",           str(mpe_address))]
 
     def _deal_with_call_response(self, response):
         if (self.args.save_response):


### PR DESCRIPTION
snet-daemon [#495](https://github.com/singnet/snet-daemon/issues/495) added `snet-payment-mpe-address` in header for paid call.

MPEClient in snet-cli will have header `snet-payment-mpe-address` in rpc call for paid service call.