### PR TITLE
Add media options (add, remove, remove-all, swap-order, change-all-order) for service metadata

### DIFF
--- a/packages/snet_cli/snet/snet_cli/metadata/service.py
+++ b/packages/snet_cli/snet/snet_cli/metadata/service.py
@@ -72,7 +72,8 @@ class MPEServiceMetadata:
                   "model_ipfs_hash": "",
                   "mpe_address": "",
                   "groups": [],
-                  "assets": {}
+                  "assets": {},
+                  "media": []
                   }
 
     def set_simple_field(self, f, v):
@@ -197,6 +198,31 @@ class MPEServiceMetadata:
                 self.m['assets'][asset_type] = []
             else:
                 raise Exception("Invalid asset type %s" % asset_type)
+
+    def add_media(self, url, media_type, hero_img=False):
+        if 'media' not in self.m:
+            self.m['media'] = []
+        if len(self.m['media']) == 0:
+            media_order = 1
+        else:
+            media_order = self.m['media'][-1]['order'] + 1
+        individual_media = {'file_type': media_type, 'url': url, 'order': media_order}
+        if media_type == 'image':
+            individual_media['alt_text'] = 'hover_on_the_image_text'
+        else:
+            individual_media['alt_text'] = 'hover_on_the_video_url'
+        if hero_img == True:
+            if media_type == 'video':
+                raise Exception("Video media type cannot be a hero-image")
+            individual_media['asset_type'] = 'hero'
+        self.m['media'].append(individual_media)
+
+
+    def remove_all_media(self):
+        pass
+
+    def remove_media(self):
+        pass
 
     def add_endpoint_to_group(self, group_name, endpoint):
         if re.match("^\w+://", endpoint) is None:

--- a/packages/snet_cli/snet/snet_cli/metadata/service.py
+++ b/packages/snet_cli/snet/snet_cli/metadata/service.py
@@ -200,7 +200,7 @@ class MPEServiceMetadata:
                 raise Exception("Invalid asset type %s" % asset_type)
 
     def add_media(self, url, media_type, hero_img=False):
-        """Add new individual media to service metadata"""
+        """Add new individual media to service metadata."""
         if 'media' not in self.m:
             self.m['media'] = []
         individual_media = {}
@@ -212,8 +212,8 @@ class MPEServiceMetadata:
             individual_media['order'] = 1
         else:
             individual_media['order'] = self.m['media'][-1]['order'] + 1
-        individual_media['file_type'] = media_type
         individual_media['url'] = url
+        individual_media['file_type']
         if media_type == 'image':
             individual_media['alt_text'] = 'hover_on_the_image_text'
         else:
@@ -221,7 +221,7 @@ class MPEServiceMetadata:
         self.m['media'].append(individual_media)
 
     def remove_media(self, order):
-        """Remove individual media from service metadata using unique order key"""
+        """Remove individual media from service metadata using unique order key."""
         assert (len(self.m['media']) > 0), "No media content to remove."
         assert (order > 0), "Order of individual media starts from 1."
         del_position = -1
@@ -236,8 +236,37 @@ class MPEServiceMetadata:
             self.m['media'][i]['order'] -= 1
 
     def remove_all_media(self):
-        """Remove all individual media from metadata"""
+        """Remove all individual media from metadata."""
         self.m['media'].clear()
+
+    def swap_media_order(self, move_from, move_to):
+        """Swap orders of two different media given their individual orders (move_from, move_to)."""
+        assert (len(self.m['media']) + 1 > move_from > 0), f"Order {move_from} out of bounds."
+        assert (len(self.m['media']) + 1 > move_to > 0), f"Order {move_to} out of bounds."
+        self.m['media'][move_to-1], self.m['media'][move_from-1] = self.m['media'][move_from-1], self.m['media'][move_to-1]
+        self.m['media'][move_to-1]['order'], self.m['media'][move_from-1]['order'] = self.m['media'][move_from-1]['order'], self.m['media'][move_to-1]['order']
+
+    def change_media_order(self):
+        """Mini REPL to change order of all individual media"""
+        order_range = range(1, len(self.m['media']) + 1)
+        available_orders = list(order_range)
+        for individual_media in self.m['media']:
+            print(f"File Type: {individual_media['file_type']}, Current Order: {individual_media['order']}")
+            while True:
+                try:
+                    new_order = int(input(f"Enter new order for {individual_media['url']}: "))
+                except ValueError:
+                    print("Error: Order entered not a number. Try again.")
+                else:
+                    if new_order in available_orders:
+                        individual_media['order'] = new_order
+                        available_orders.remove(new_order)
+                        break
+                    elif new_order not in order_range:
+                        print(f"Media array contains only {len(self.m['media'])} items. Enter order between [{order_range.start}, {order_range.stop-1}]")
+                    else:
+                        print(f"Order already taken. Available orders: {available_orders}")
+        self.m['media'].sort(key=lambda x: x['order'])
 
     def __is_asset_type_exists(self):
         """Return boolean on whether asset type already exists"""

--- a/packages/snet_cli/snet_cli/arguments.py
+++ b/packages/snet_cli/snet_cli/arguments.py
@@ -1108,7 +1108,6 @@ def add_mpe_service_options(parser):
     p.set_defaults(fn="metadata_remove_all_assets")
     add_p_metadata_file_opt(p)
 
-    # metadata-add-media subparser
     p = subparsers.add_parser("metadata-add-media",
                               help="Add media to metadata")
     p.set_defaults(fn="metadata_add_media")
@@ -1120,10 +1119,22 @@ def add_mpe_service_options(parser):
                    choices=['image', 'video'],
                    help="Type of the media [image, video]")
     p.add_argument('--hero_image',
-                   metavar='bool',
                    help='Indicate whether hero-image (default False)',
-                   type=bool,
-                   default=False)
+                   action='store_true')
+    add_p_metadata_file_opt(p)
+
+    p = subparsers.add_parser("metadata-remove-media",
+                              help="Remove media of asset type")
+    p.set_defaults(fn="metadata_remove_media")
+    p.add_argument("order",
+                   metavar="ORDER",
+                   help="Delete by order of media",
+                   type=int)
+    add_p_metadata_file_opt(p)
+
+    p = subparsers.add_parser("metadata-remove-all-media",
+                              help="Remove all existing media")
+    p.set_defaults(fn="metadata_remove_all_media")
     add_p_metadata_file_opt(p)
 
     p = subparsers.add_parser("metadata-update-endpoints",

--- a/packages/snet_cli/snet_cli/arguments.py
+++ b/packages/snet_cli/snet_cli/arguments.py
@@ -1118,7 +1118,7 @@ def add_mpe_service_options(parser):
                    metavar='MEDIA_TYPE',
                    choices=['image', 'video'],
                    help="Type of the media [image, video]")
-    p.add_argument('--hero_image',
+    p.add_argument('--hero-image',
                    help='Indicate whether hero-image (default False)',
                    action='store_true')
     add_p_metadata_file_opt(p)

--- a/packages/snet_cli/snet_cli/arguments.py
+++ b/packages/snet_cli/snet_cli/arguments.py
@@ -1108,6 +1108,24 @@ def add_mpe_service_options(parser):
     p.set_defaults(fn="metadata_remove_all_assets")
     add_p_metadata_file_opt(p)
 
+    # metadata-add-media subparser
+    p = subparsers.add_parser("metadata-add-media",
+                              help="Add media to metadata")
+    p.set_defaults(fn="metadata_add_media")
+    p.add_argument("media_url",
+                   metavar='MEDIA_URL',
+                   help="Media url endpoint")
+    p.add_argument("media_type",
+                   metavar='MEDIA_TYPE',
+                   choices=['image', 'video'],
+                   help="Type of the media [image, video]")
+    p.add_argument('--hero_image',
+                   metavar='bool',
+                   help='Indicate whether hero-image (default False)',
+                   type=bool,
+                   default=False)
+    add_p_metadata_file_opt(p)
+
     p = subparsers.add_parser("metadata-update-endpoints",
                               help="Remove all endpoints from the group and add new ones")
     p.set_defaults(fn="metadata_update_endpoints")

--- a/packages/snet_cli/snet_cli/arguments.py
+++ b/packages/snet_cli/snet_cli/arguments.py
@@ -1114,11 +1114,7 @@ def add_mpe_service_options(parser):
     p.add_argument("media_url",
                    metavar='MEDIA_URL',
                    help="Media url endpoint")
-    p.add_argument("media_type",
-                   metavar='MEDIA_TYPE',
-                   choices=['image', 'video'],
-                   help="Type of the media [image, video]")
-    p.add_argument('--hero-image',
+    p.add_argument('--hero_image',
                    help='Indicate whether hero-image (default False)',
                    action='store_true')
     add_p_metadata_file_opt(p)
@@ -1135,6 +1131,24 @@ def add_mpe_service_options(parser):
     p = subparsers.add_parser("metadata-remove-all-media",
                               help="Remove all existing media")
     p.set_defaults(fn="metadata_remove_all_media")
+    add_p_metadata_file_opt(p)
+
+    p = subparsers.add_parser("metadata-swap-media-order",
+                              help="Swap media order")
+    p.set_defaults(fn="metadata_swap_media_order")
+    p.add_argument("move_from",
+                   metavar="FROM",
+                   help="Order number to swap from",
+                   type=int)
+    p.add_argument("move_to",
+                   metavar="TO",
+                   help="Order number to swap to",
+                   type=int)
+    add_p_metadata_file_opt(p)
+
+    p = subparsers.add_parser("metadata-change-media-order",
+                              help="Reassign all individual media order")
+    p.set_defaults(fn="metadata_change_media_order")
     add_p_metadata_file_opt(p)
 
     p = subparsers.add_parser("metadata-update-endpoints",

--- a/packages/snet_cli/snet_cli/commands/mpe_service.py
+++ b/packages/snet_cli/snet_cli/commands/mpe_service.py
@@ -157,6 +157,11 @@ class MPEServiceCommand(BlockchainCommand):
         metadata.remove_assets(self.args.asset_type)
         metadata.save_pretty(self.args.metadata_file)
 
+    def metadata_add_media(self):
+        metadata = load_mpe_service_metadata(self.args.metadata_file)
+        metadata.add_media(self.args.media_url, self.args.media_type, self.args.hero_image)
+        metadata.save_pretty((self.args.metadata_file))
+
     def metadata_add_contributor(self):
         metadata = load_mpe_service_metadata(self.args.metadata_file)
         metadata.add_contributor(self.args.name, self.args.email_id)

--- a/packages/snet_cli/snet_cli/commands/mpe_service.py
+++ b/packages/snet_cli/snet_cli/commands/mpe_service.py
@@ -158,9 +158,22 @@ class MPEServiceCommand(BlockchainCommand):
         metadata.save_pretty(self.args.metadata_file)
 
     def metadata_add_media(self):
+        """Metadata: Add new individual media"""
         metadata = load_mpe_service_metadata(self.args.metadata_file)
         metadata.add_media(self.args.media_url, self.args.media_type, self.args.hero_image)
-        metadata.save_pretty((self.args.metadata_file))
+        metadata.save_pretty(self.args.metadata_file)
+
+    def metadata_remove_media(self):
+        """Metadata: Remove individual media using unique order key"""
+        metadata = load_mpe_service_metadata(self.args.metadata_file)
+        metadata.remove_media(self.args.order)
+        metadata.save_pretty(self.args.metadata_file)
+
+    def metadata_remove_all_media(self):
+        """Metadata: Remove all individual media"""
+        metadata = load_mpe_service_metadata(self.args.metadata_file)
+        metadata.remove_all_media()
+        metadata.save_pretty(self.args.metadata_file)
 
     def metadata_add_contributor(self):
         metadata = load_mpe_service_metadata(self.args.metadata_file)

--- a/packages/snet_cli/test/unit_tests/test_mpe_service_metadata_2.py
+++ b/packages/snet_cli/test/unit_tests/test_mpe_service_metadata_2.py
@@ -1,0 +1,30 @@
+import unittest
+from snet.snet_cli.metadata.service import MPEServiceMetadata
+
+
+class TestMediaMethods(unittest.TestCase):
+    def setUp(self):
+        self.metadata = MPEServiceMetadata()
+        self.mock_data = dict(asset_type='hero_image',
+                              order=1,
+                              file_type='image',
+                              url='www.example.com',
+                              alt_text='hover_on_the_image_text')
+
+    def test_add_media(self):
+        self.metadata.add_media('www.example.com', 'image', True)
+        self.assertEqual(self.metadata['media'][0], self.mock_data)
+        self.assertRaises(AssertionError, self.metadata.add_media, 'www.example.com', 'image', True)
+        self.assertRaises(AssertionError, self.metadata.add_media, 'www.example.com', 'video', True)
+
+    def test_remove_media(self):
+        self.assertRaises(AssertionError, self.metadata.remove_media, 1)
+        self.assertRaises(AssertionError, self.metadata.remove_media, -1)
+        self.metadata['media'].append(self.mock_data)
+        self.assertRaises(Exception, self.metadata.remove_media, 2)
+        self.assertIsNone(self.metadata.remove_media(1))
+        self.assertRaises(AssertionError, self.metadata.remove_media, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What?
I've added media commands in the **snet service** (`add_media`, `remove_media`, `remove_all_media`, `swap_media_order`, and `change_media_order`). Unit test cases for `swap_media_order` and `change_media_order` are yet to come.
## How?
`add_media`: Checks for if desired file type (video file type cannot be a hero image) and if hero image already exists. Individual media are identified by a unique 'order' key and are stored as a dictionary (object) in the service metadata's 'media' array.

> **Update (22nd March 2021)**: 
> 
> - Implemented implicit file extension detection. User no longer includes file type as an argument in CLI.
> - URL directly added if an external resource (ensures endpoints carry SSL certification.)
> - Appended with CID and filename if new asset needs to be added on IPFS.

`remove_media`: Removes media by the unique 'order' key. Asserts are raised if no individual media are left to remove or negative ordering is provided. Order consistency (after removal) for the other individual media items is maintained.

`remove_all_media`: Removes all individual media items in the service metadata's 'media' array.

_TL; DR_ changes in arguments.py module:  `--hero-image` used to indicate individual media as hero image (uses `action='store_true'` to store boolean True.) 

**Update (22nd March 2021):**
`swap_media_order`: Swaps two individual media items using a 'move_from' and 'move_to' as order keys. (WHY? If the user wants to move a media to a higher priority.)

`change_media_order`: REPL to change the order of all individual media items in the media array. (WHY? Provides the user to make changes instead of reinitializing.)

**Update (12th April 2021):**
`snet service metadata-init`: A straightforward utility for service metadata initialization.

Validation checks of service metadata consistency and value existence are implemented.

Sample media structure:
```
...
"media": [
      {
         "order": 1,
         "file_type": "video",
         "url": "https://www.example.com",
         "alt_text": "hover_on_the_video_url"
      },
      {
         "asset-type": "hero-image",
         "order": 2,
         "file_type": "image",
         "url": "<CID_Hash>/example_file.jpg",
         "alt_text": "hover_on_the_image_text"
      }
]
```
### Anything Else?
- Method import (efficiency?): The `mpe_service.py` now imports the `search` method from Python's RegEx package (re.)
- Existing bugs: If a file does not exist while publishing to IPFS, the [error is printed](https://github.com/singnet/snet-cli/blob/f587902d49225ba166c4b133a1adcfcec8ce2b62/packages/snet_cli/snet/snet_cli/utils/ipfs_utils.py#L23) rather than raising an exception and halting execution.