### PR TITLE
SnetSDK | Fixes channel processing issue

### DIFF
--- a/packages/sdk/snet/sdk/mpe/payment_channel_provider.py
+++ b/packages/sdk/snet/sdk/mpe/payment_channel_provider.py
@@ -4,7 +4,7 @@ from snet.sdk.mpe.mpe_contract import MPEContract
 from snet.sdk.mpe.payment_channel import PaymentChannel
 from snet.snet_cli.utils.utils import get_contract_deployment_block
 
-BLOCKS_PER_BATCH = 20000
+BLOCKS_PER_BATCH = 5000
 
 
 class PaymentChannelProvider(object):


### PR DESCRIPTION
1. Get Ethereum log has a limit to filter logs up to 10000.
2. But we are having more than 10000 logs within the range of 20000 blocks.
3. Reducing the batch limit from 20000 to 5000.