### PR TITLE
[SPT-217] Add request_kwargs for HTTPProvider

### DIFF
--- a/packages/sdk/snet/sdk/__init__.py
+++ b/packages/sdk/snet/sdk/__init__.py
@@ -38,7 +38,10 @@ class SnetSDK:
 
         # Instantiate Ethereum client
         eth_rpc_endpoint = self._config.get("eth_rpc_endpoint", "https://mainnet.infura.io/v3/e7732e1f679e461b9bb4da5653ac3fc2")
-        provider = web3.HTTPProvider(eth_rpc_endpoint)
+        eth_rpc_request_kwargs = self._config.get("eth_rpc_request_kwargs")
+
+        provider = web3.HTTPProvider(endpoint_uri=eth_rpc_endpoint, request_kwargs=eth_rpc_request_kwargs)
+
         self.web3 = web3.Web3(provider)
 
         # Get MPE contract address from config if specified; mostly for local testing


### PR DESCRIPTION
Implemented the use of API SECRET for Infura via optional argument `request_kwargs` in `SnetSDK` constructor for `HTTPProvider` constructor in module Web3