### PR TITLE
Hide UserWarnings at the time the logs processing

### DIFF
--- a/snet/cli/contract.py
+++ b/snet/cli/contract.py
@@ -1,3 +1,6 @@
+from web3.logs import DISCARD
+
+
 class Contract:
     def __init__(self, w3, address, abi):
         self.w3 = w3
@@ -22,6 +25,6 @@ class Contract:
 
         contract_events = map(lambda e: e["name"], filter(lambda e: e["type"] == "event", self.abi))
         for contract_event in contract_events:
-            events.extend(getattr(self.contract.events, contract_event)().process_receipt(receipt))
+            events.extend(getattr(self.contract.events, contract_event)().process_receipt(receipt, errors=DISCARD))
 
         return events


### PR DESCRIPTION
We have `UserWarnings` every time the logs are received after a transaction.

`UserWarning: The log with transaction hash: <hash> and logIndex: <log index> encountered the following error during processing: MismatchedABI(The event signature did not match the provided ABI). It has been discarded.`

This fix hides these warnings.